### PR TITLE
bugfix: rules vote qualification wording

### DIFF
--- a/packages/react-app-revamp/pages/contest/[chain]/[address]/rules/index.tsx
+++ b/packages/react-app-revamp/pages/contest/[chain]/[address]/rules/index.tsx
@@ -69,7 +69,7 @@ const Page: NextPage = (props: PageProps) => {
          </span>
            
            </li>
-         <li>Submitters qualify to vote if they have token by <span className="font-bold">{format(usersQualifyToVoteIfTheyHoldTokenAtTime, "PPP p")}</span></li>
+         <li>Token holders qualify to vote if they have token by <span className="font-bold">{format(usersQualifyToVoteIfTheyHoldTokenAtTime, "PPP p")}</span></li>
          <li>
            <span className='font-bold'>Contest accepts up to {new Intl.NumberFormat().format(contestMaxProposalCount)} proposals</span>{" "}total
           </li>


### PR DESCRIPTION
# Bug description
> Confusing wording in the contest rules for how does a user qualify to vote

## Fix description
Change the wording in the Rules contest page to ease understanding of how/when a user qualify to vote.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
