### PR TITLE
bugfix: remove lowercase text transform from proposal content

### DIFF
--- a/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
@@ -3,6 +3,7 @@ import { isUrlTweet } from "@helpers/isUrlTweet";
 import { TwitterTweetEmbed } from "react-twitter-embed";
 import { Interweave } from "interweave";
 import { UrlMatcher } from "interweave-autolink";
+import styles from './styles.module.css'
 interface ProposalContentProps {
   content: string;
   author: string;
@@ -26,7 +27,7 @@ function renderContent(str: string) {
     );
   }
   return (
-    <div className="with-link-highlighted">
+    <div className={`with-link-highlighted ${styles.content}`}>
       <Interweave content={str} matchers={[new UrlMatcher("url")]} />
     </div>
   );

--- a/packages/react-app-revamp/components/_pages/ProposalContent/styles.module.css
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/styles.module.css
@@ -1,0 +1,3 @@
+.content * {
+    @apply normal-case !important;
+}


### PR DESCRIPTION
# Bug description
> submissions aren't recognizing capital letters (i tried one writing ARRAYS and it rendered as arrays)

## Fix description
Remove the `lowercase` enforced style by scoping `normal-case` (see [TailwindCSS text-transform](https://tailwindcss.com/docs/text-transform#transforming-text)) in a css module and applying it to `ProposalContent` text and its children

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)