### PR TITLE
Bugfix/cant submit proposal on connect

### DIFF
--- a/packages/react-app-revamp/components/TrackerDeployTransaction/styles.module.css
+++ b/packages/react-app-revamp/components/TrackerDeployTransaction/styles.module.css
@@ -9,6 +9,6 @@
 }
 
 .stepper li::before {
-  @apply bg-neutral-1 px-2 text-sm inline-flex items-center justify-center mie-1ex aspect-square rounded-full border-solid border-current border;
+  @apply bg-neutral-1 text-sm inline-flex items-center justify-center mie-1ex w-7 h-7 rounded-full border-solid border-current border;
   content: counter(my-awesome-counter);
 }

--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/StepIndicator/index.tsx
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/StepIndicator/index.tsx
@@ -109,7 +109,7 @@ export const StepIndicator = () => {
                         //@ts-ignore
                         onClick={() => setCurrentStep(parseInt(indicator))}
                       >
-                        <span className="px-1 bg-true-black text-2xs flex items-center justify-center mie-1ex aspect-square rounded-full border-solid border-current border">
+                        <span className="px-1 bg-true-black text-2xs flex items-center justify-center mie-1ex w-6 h-6 rounded-full border-solid border-current border">
                           {indicator}
                         </span>
                         {/* @ts-ignore */}


### PR DESCRIPTION
# Bug description
_As a user with their wallet not connected_
- When I connect my wallet
- And I click on 'Submit' to submit a new proposal

*Expected result*
I should see the form to submit a new proposal in the modal
 
*Actual outcome*
I see "You can't submit more proposals"

## Fix description
In `updateCurrentUserVotes()` (`hooks/useContest`), in the multicall, `getVotes` needs the current user wallet address as an argument.
Initially we would get the address with `useAccount()` hook.
It appears that when we first connect the wallet, the address returned by `useAccount()` is `undefined`. 
To solve this, instead of getting the user address from `useAccount()`, we use `getAccount()` from `wagmi/core` in the function.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Additional changes
- Styling fixes (steppers look a bit squary, using a fixed width/height instead of an aspect ratio fixes this)