### PR TITLE
bugfix - countdown error on past contests

### DIFF
--- a/packages/react-app-revamp/helpers/updateCountdown.ts
+++ b/packages/react-app-revamp/helpers/updateCountdown.ts
@@ -1,8 +1,9 @@
 import { differenceInHours, intervalToDuration } from "date-fns";
+import { isBefore } from "date-fns";
 
 export function updateCountdown(countdownEndDatetime: Date) {
   const interval = intervalToDuration({
-    start: new Date(),
+    start: (isBefore(new Date(), countdownEndDatetime) ? new Date() : countdownEndDatetime),
     end: countdownEndDatetime,
   });
 


### PR DESCRIPTION
fixes #24 

Ensures that start time is never before endtime in updateCountdown.