### PR TITLE
Bugfix 29/searching same address twice infinite loading

### DIFF
--- a/packages/react-app-revamp/components/_pages/FormSearchContest/index.tsx
+++ b/packages/react-app-revamp/components/_pages/FormSearchContest/index.tsx
@@ -13,26 +13,28 @@ import { getNetwork } from "@wagmi/core";
 interface FormSearchContestProps {
   isInline?: boolean;
   onSubmit?: (address: string) => void;
+  retry?: any
 }
 
 export const FormSearchContest = (props: FormSearchContestProps) => {
-  const { isInline, onSubmit } = props;
+  const { isInline, onSubmit, retry } = props;
   const { chain } = useNetwork();
   const { asPath, push, pathname, events } = useRouter();
   const [showLoader, setShowLoader] = useState(false);
   const { form, errors } = useForm({
     extend: validator({ schema }),
     onSubmit: values => {
+      const contestAddress = asPath.split("/")[3];
       if (!chain || chain.unsupported === true) return;
       const currentChain = asPath.split("/")[2];
-      getNetwork;
       push(
         ROUTE_VIEW_CONTEST,
-        `/contest/${currentChain ?? getNetwork()?.chain?.name.toLowerCase().replace(' ', '')}/${values.contestAddress}`,
+        `/contest/${!currentChain  || currentChain !== getNetwork()?.chain?.name.toLowerCase().replace(' ', '') ? getNetwork()?.chain?.name.toLowerCase().replace(' ', '') : currentChain }/${values.contestAddress}`,
         {
           shallow: true,
         },
       );
+      if(contestAddress && contestAddress === values.contestAddress) return
       if (pathname !== ROUTE_VIEW_CONTESTS) {
         //@ts-ignore
         onSubmit(values.contestAddress);

--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -159,7 +159,7 @@ const LayoutViewContest = (props: any) => {
     <>
       <div className={`${isLoading ? "pointer-events-none" : ""} border-b border-solid border-neutral-2 py-2`}>
         <div className="container mx-auto">
-          <FormSearchContest onSubmit={onSearch} isInline={true} />
+          <FormSearchContest onSubmit={onSearch} retry={retry} isInline={true} />
         </div>
       </div>
       <div


### PR DESCRIPTION
Should fix #29 

# Description

>  After using the search bar on the View Contests page once, using it again will result in a page that never loads, forcing you to hard reload the page.

Fixes infinite loading when user uses the same contest address in the search form of the contest page by preventing the search function from being called when the contest address in the url is the same as the contest address in the search bar.

## Type of change

- [x] Bugfix (non-breaking)

# How Has This Been Tested?

Scenario 1: wrong network
1. Go to "View contests" page
2. Type `0x3Aa9538c6aCD23526fF72f75A9b9160a275379C3` in the search bar.
3. After seeing the loader, you should see an error message and a try again button
4. Inputting the same address in the search bar and clicking on 'Search' should give you the same result as **step 3**
5. Change network to 'Polygon'
6. You should see the loader, and the contest data appearing after a few seconds
7. Inputting the same address in the search bar and clicking on 'Search' should give you the same result as **step 6**

Scenario 2: right network
1. Go to "View contests" page
2. Type `0x3Aa9538c6aCD23526fF72f75A9b9160a275379C3` in the search bar.
3. The loader should appear
4. The contest data appear after a few seconds
5. Input the same address in the search bar 
6. The loader should appear
7. The contest data appear after a few seconds