### PR TITLE
Bugfix/available number of votes to cast is inacurate

### DIFF
--- a/packages/react-app-revamp/components/_pages/DialogModalVoteForProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalVoteForProposal/index.tsx
@@ -39,7 +39,7 @@ export const DialogModalVoteForProposal = (props: DialogModalVoteForProposalProp
   //@ts-ignore
   const { castVotes, isLoading, error, isSuccess } = useCastVotes();
 
-  const [votesToCast, setVotesToCast] = useState(1);
+  const [votesToCast, setVotesToCast] = useState(currentUserAvailableVotesAmount < 1 ? currentUserAvailableVotesAmount : 1);
   const [showForm, setShowForm] = useState(true);
   const [showDeploymentSteps, setShowDeploymentSteps] = useState(false);
   useEffect(() => {
@@ -50,7 +50,7 @@ export const DialogModalVoteForProposal = (props: DialogModalVoteForProposalProp
 
   useEffect(() => {
     if (props.isOpen === false && !isLoading) {
-      setVotesToCast(1);
+      setVotesToCast(currentUserAvailableVotesAmount < 1 ? currentUserAvailableVotesAmount : 1);
       setShowForm(true);
       setShowDeploymentSteps(false);
     }

--- a/packages/react-app-revamp/components/_pages/DialogModalVoteForProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalVoteForProposal/index.tsx
@@ -128,7 +128,7 @@ export const DialogModalVoteForProposal = (props: DialogModalVoteForProposalProp
                 id="input-contestaddress-helpblock-1"
                 hasError={votesToCast <= 0 || votesToCast > currentUserAvailableVotesAmount}
               >
-                <span>Available: {new Intl.NumberFormat().format(currentUserAvailableVotesAmount)}</span>
+                <span>Available: {currentUserAvailableVotesAmount}</span>
                 {pickedProposal !== null && (
                   <span>
                     Votes on submission: {new Intl.NumberFormat().format(listProposalsData[pickedProposal].votes)}{" "}

--- a/packages/react-app-revamp/components/_pages/FormSearchContest/index.tsx
+++ b/packages/react-app-revamp/components/_pages/FormSearchContest/index.tsx
@@ -28,7 +28,7 @@ export const FormSearchContest = (props: FormSearchContestProps) => {
       getNetwork;
       push(
         ROUTE_VIEW_CONTEST,
-        `/contest/${currentChain ?? getNetwork()?.chain?.name.toLowerCase()}/${values.contestAddress}`,
+        `/contest/${currentChain ?? getNetwork()?.chain?.name.toLowerCase().replace(' ', '')}/${values.contestAddress}`,
         {
           shallow: true,
         },

--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/index.tsx
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/index.tsx
@@ -101,7 +101,7 @@ export const Step3 = () => {
               href={{
                 pathname: ROUTE_VIEW_CONTEST,
                 //@ts-ignore
-                query: { chain: contestDeployedToChain?.name.toLocaleLowerCase(), address: dataDeployContest?.address },
+                query: { chain: contestDeployedToChain?.name.toLowerCase().replace(" ", ""), address: dataDeployContest?.address },
               }}
             >
               <a target="_blank">

--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step4/TextInstructions.tsx
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step4/TextInstructions.tsx
@@ -52,7 +52,7 @@ export const TextInstructions = () => {
                   pathname: ROUTE_VIEW_CONTEST,
                   //@ts-ignore
                   query: {
-                    chain: contestDeployedToChain.name.toLowerCase(),
+                    chain: contestDeployedToChain.name.toLowerCase().replace(' ', ''),
                     address: dataDeployContest?.address,
                   },
                 }}

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -14,7 +14,7 @@ export function useContest() {
   const provider = useProvider();
   const { asPath } = useRouter();
   const [chainId, setChaindId] = useState(
-    chains.filter(chain => chain.name.toLowerCase() === asPath.split("/")[2])?.[0]?.id,
+    chains.filter(chain => chain.name.toLowerCase().replace(' ', '') === asPath.split("/")[2])?.[0]?.id,
   );
   const [address, setAddress] = useState(asPath.split("/")[3]);
   const {

--- a/packages/react-app-revamp/hooks/useExportContestDataToCSV/useExportContestDataToCSV.ts
+++ b/packages/react-app-revamp/hooks/useExportContestDataToCSV/useExportContestDataToCSV.ts
@@ -25,7 +25,7 @@ export function useExportContestDataToCSV() {
 
   async function fetchProposalVoters(proposalId: number | string) {
     const url = asPath.split("/");
-    const chainId = chains.filter(chain => chain.name.toLowerCase() === url[2])?.[0]?.id;
+    const chainId = chains.filter(chain => chain.name.toLowerCase().replace(' ', '') === url[2])?.[0]?.id;
     const address = url[3];
     const abi = await getContestContractVersion(address);
     if (abi === null) {
@@ -51,7 +51,7 @@ export function useExportContestDataToCSV() {
 
   async function fetchVotesPerAddress(id: number | string, userAddress: string) {
     const url = asPath.split("/");
-    const chainId = chains.filter(chain => chain.name.toLowerCase() === url[2])?.[0]?.id;
+    const chainId = chains.filter(chain => chain.name.toLowerCase().replace(' ', '') === url[2])?.[0]?.id;
     const address = url[3];
     const abi = await getContestContractVersion(address);
     if (abi === null) {

--- a/packages/react-app-revamp/hooks/useProposalVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useProposalVotes/index.ts
@@ -16,7 +16,7 @@ export function useProposalVotes(id: number | string) {
   const account = useAccount();
   const { chain } = useNetwork();
   const [url] = useState(asPath.split("/"));
-  const [chainId, setChainId] = useState(chains.filter(chain => chain.name.toLowerCase() === url[2])?.[0]?.id);
+  const [chainId, setChainId] = useState(chains.filter(chain => chain.name.toLowerCase().replace(' ', '') === url[2])?.[0]?.id);
   const [address] = useState(url[3]);
 
   const { listProposalsData } = useStoreContest(

--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -122,7 +122,7 @@ const LayoutViewContest = (props: any) => {
   }, [chain?.id, chainId, asPath.split("/")[2], asPath.split("/")[3]]);
 
   useEffect(() => {
-    const chainName = chains.filter(chain => chain.id === chainId)?.[0]?.name.toLowerCase();
+    const chainName = chains.filter(chain => chain.id === chainId)?.[0]?.name.toLowerCase().replace(' ', '');
     if (asPath.split("/")[2] !== chainName) {
       if (pathname === ROUTE_VIEW_CONTEST) {
         let newRoute = pathname

--- a/packages/react-app-revamp/pages/contest/[chain]/[address]/export-data/index.tsx
+++ b/packages/react-app-revamp/pages/contest/[chain]/[address]/export-data/index.tsx
@@ -47,7 +47,7 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ params }: any) {
   const { chain, address } = params
-  if (!REGEX_ETHEREUM_ADDRESS.test(address) || chains.filter(c => c.name.toLowerCase() === chain).length === 0 ) {
+  if (!REGEX_ETHEREUM_ADDRESS.test(address) || chains.filter(c => c.name.toLowerCase().replace(' ', '') === chain).length === 0 ) {
     return { notFound: true }
   }
 

--- a/packages/react-app-revamp/pages/contest/[chain]/[address]/index.tsx
+++ b/packages/react-app-revamp/pages/contest/[chain]/[address]/index.tsx
@@ -45,7 +45,7 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ params }: any) {
   const { chain, address } = params
-  if (!REGEX_ETHEREUM_ADDRESS.test(address) || chains.filter(c => c.name.toLowerCase() === chain).length === 0 ) {
+  if (!REGEX_ETHEREUM_ADDRESS.test(address) || chains.filter(c => c.name.toLowerCase().replace(' ', '') === chain).length === 0 ) {
     return { notFound: true }
   }
 

--- a/packages/react-app-revamp/pages/contest/[chain]/[address]/proposal/[proposal].tsx
+++ b/packages/react-app-revamp/pages/contest/[chain]/[address]/proposal/[proposal].tsx
@@ -75,7 +75,7 @@ const Page: NextPage = (props: PageProps) => {
           onClick={onClickProposalVote}>
             {!checkIfUserPassedSnapshotLoading ? 'Cast your votes for this proposal' : 'Checking snapshot...'}
         </Button>
-        <span className='text-2xs mt-1 text-neutral-11'>Available: {new Intl.NumberFormat().format(currentUserAvailableVotesAmount)}</span>
+        <span className='text-2xs mt-1 text-neutral-11'>Available: {currentUserAvailableVotesAmount}</span>
         {<p className='text-2xs mt-1 text-neutral-11'>{checkIfUserPassedSnapshotLoading ? 'Checking snapshot...': !didUserPassSnapshotAndCanVote ? 'Your wallet didn\'t qualify to vote.' : 'Your wallet qualified to vote!'}</p>}
         </div>}
         {[CONTEST_STATUS.VOTING_OPEN, CONTEST_STATUS.COMPLETED].includes(contestStatus)  &&  <ProviderProposalVotes createStore={createStoreProposalVotes}>

--- a/packages/react-app-revamp/pages/contest/[chain]/[address]/proposal/[proposal].tsx
+++ b/packages/react-app-revamp/pages/contest/[chain]/[address]/proposal/[proposal].tsx
@@ -98,7 +98,7 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ params }: any) {
   const { chain, address } = params
-  if (!REGEX_ETHEREUM_ADDRESS.test(address) || chains.filter(c => c.name.toLowerCase() === chain).length === 0 ) {
+  if (!REGEX_ETHEREUM_ADDRESS.test(address) || chains.filter(c => c.name.toLowerCase().replace(' ', '') === chain).length === 0 ) {
     return { notFound: true }
   }
 

--- a/packages/react-app-revamp/pages/contest/[chain]/[address]/rules/index.tsx
+++ b/packages/react-app-revamp/pages/contest/[chain]/[address]/rules/index.tsx
@@ -100,7 +100,7 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ params }: any) {
   const { chain, address } = params
-  if (!REGEX_ETHEREUM_ADDRESS.test(address) || chains.filter(c => c.name.toLowerCase() === chain).length === 0 ) {
+  if (!REGEX_ETHEREUM_ADDRESS.test(address) || chains.filter(c => c.name.toLowerCase().replace(' ', '') === chain).length === 0 ) {
     return { notFound: true }
   }
 


### PR DESCRIPTION
# Description
Remove `Intl.NumberFormat()` in the current user available number of votes. Sadly, it rounds numbers by default ([see documentation](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat)), which caused this bug.

Should fix #23


## Type of change

- [x] Bugfix (non-breaking)

# How Has This Been Tested?
Pre-requisite: choose a testnet and get some testnet tokens !

1. Go to 'create contest' and go to 'Mint token'
2. Create a token with a max supply of `1`, and pick your address as the receiver
3. Create a contest
4. Go to the contest page
5. Submit a proposal and wait for votes to open (Current state [screenshot](https://imgur.com/a/7JJopeH))
6. Click on the vote button
7. In the input, type a number with decimals (like 0.01)
8. Click on 'Vote!'
9. Wait for the transaction to be successful 
10. Click on the vote button again
11. 'Available'  should displays  the accurate number of vote, and not a formatted rounded number anymore

Additionally, if the current user available number of votes is < 1, the displayed default number in the input won't be `1`, but the current user available number of votes.