### PR TITLE
bugfix: inacurate amount of available votes displayed

### DIFF
--- a/packages/react-app-revamp/components/_pages/DialogModalVoteForProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalVoteForProposal/index.tsx
@@ -39,7 +39,7 @@ export const DialogModalVoteForProposal = (props: DialogModalVoteForProposalProp
   //@ts-ignore
   const { castVotes, isLoading, error, isSuccess } = useCastVotes();
 
-  const [votesToCast, setVotesToCast] = useState(1);
+  const [votesToCast, setVotesToCast] = useState(currentUserAvailableVotesAmount < 1 ? currentUserAvailableVotesAmount : 1);
   const [showForm, setShowForm] = useState(true);
   const [showDeploymentSteps, setShowDeploymentSteps] = useState(false);
   useEffect(() => {
@@ -50,7 +50,7 @@ export const DialogModalVoteForProposal = (props: DialogModalVoteForProposalProp
 
   useEffect(() => {
     if (props.isOpen === false && !isLoading) {
-      setVotesToCast(1);
+      setVotesToCast(currentUserAvailableVotesAmount < 1 ? currentUserAvailableVotesAmount : 1);
       setShowForm(true);
       setShowDeploymentSteps(false);
     }
@@ -128,7 +128,7 @@ export const DialogModalVoteForProposal = (props: DialogModalVoteForProposalProp
                 id="input-contestaddress-helpblock-1"
                 hasError={votesToCast <= 0 || votesToCast > currentUserAvailableVotesAmount}
               >
-                <span>Available: {new Intl.NumberFormat().format(currentUserAvailableVotesAmount)}</span>
+                <span>Available: {currentUserAvailableVotesAmount}</span>
                 {pickedProposal !== null && (
                   <span>
                     Votes on submission: {new Intl.NumberFormat().format(listProposalsData[pickedProposal].votes)}{" "}

--- a/packages/react-app-revamp/layouts/LayoutViewContest/VotingToken/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/VotingToken/index.tsx
@@ -40,9 +40,9 @@ export const VotingToken = () => {
                       notation: "compact",
                       maximumFractionDigits: 3,
                     }).format(parseFloat(currentUserAvailableVotesAmount))
-                  : new Intl.NumberFormat().format(currentUserAvailableVotesAmount)}
+                  : parseFloat(currentUserAvailableVotesAmount.toFixed(5))}
               </span>
-              <span className="md:hidden">{new Intl.NumberFormat().format(currentUserAvailableVotesAmount)}</span>
+              <span className="md:hidden">{parseFloat(currentUserAvailableVotesAmount.toFixed(5))}</span>
             </span>
           </>
         ) : isBefore(new Date(), votesClose) ? (
@@ -54,9 +54,9 @@ export const VotingToken = () => {
                       notation: "compact",
                       maximumFractionDigits: 3,
                     }).format(parseFloat(currentUserAvailableVotesAmount))
-                  : new Intl.NumberFormat("en-US").format(currentUserAvailableVotesAmount)}
+                  : parseFloat(currentUserAvailableVotesAmount.toFixed(5))}
               </span>
-              <span className="md:hidden">{new Intl.NumberFormat("en-US").format(currentUserAvailableVotesAmount)}</span>
+              <span className="md:hidden">{parseFloat(currentUserAvailableVotesAmount.toFixed(5))}</span>
             </span>
             <span
               title={new Intl.NumberFormat().format(currentUserAvailableVotesAmount + currentUserTotalVotesCast)}
@@ -82,9 +82,9 @@ export const VotingToken = () => {
                   notation: "compact",
                   maximumFractionDigits: 3,
                 }).format(parseFloat(currentUserAvailableVotesAmount))
-              : new Intl.NumberFormat("en-US").format(currentUserAvailableVotesAmount)}
+              : parseFloat(currentUserAvailableVotesAmount.toFixed(5))}
           </span>
-          <span className="md:hidden">{new Intl.NumberFormat("en-US").format(currentUserAvailableVotesAmount)}</span>
+          <span className="md:hidden">{parseFloat(currentUserAvailableVotesAmount.toFixed(5))}</span>
         </span>
         <span
           title={new Intl.NumberFormat().format(currentUserAvailableVotesAmount + currentUserTotalVotesCast)}

--- a/packages/react-app-revamp/pages/contest/[chain]/[address]/proposal/[proposal].tsx
+++ b/packages/react-app-revamp/pages/contest/[chain]/[address]/proposal/[proposal].tsx
@@ -75,7 +75,7 @@ const Page: NextPage = (props: PageProps) => {
           onClick={onClickProposalVote}>
             {!checkIfUserPassedSnapshotLoading ? 'Cast your votes for this proposal' : 'Checking snapshot...'}
         </Button>
-        <span className='text-2xs mt-1 text-neutral-11'>Available: {new Intl.NumberFormat().format(currentUserAvailableVotesAmount)}</span>
+        <span className='text-2xs mt-1 text-neutral-11'>Available: {currentUserAvailableVotesAmount}</span>
         {<p className='text-2xs mt-1 text-neutral-11'>{checkIfUserPassedSnapshotLoading ? 'Checking snapshot...': !didUserPassSnapshotAndCanVote ? 'Your wallet didn\'t qualify to vote.' : 'Your wallet qualified to vote!'}</p>}
         </div>}
         {[CONTEST_STATUS.VOTING_OPEN, CONTEST_STATUS.COMPLETED].includes(contestStatus)  &&  <ProviderProposalVotes createStore={createStoreProposalVotes}>


### PR DESCRIPTION
# Description

> UI displays an inaccurate (rounded) value of the user available votes.

Remove `Intl.NumberFormat()` in the current user available number of votes. Sadly, it rounds numbers by default ([see documentation](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat)), which caused this bug.

Should fix #23

## Type of change

- [x] Bugfix (non-breaking)

# How Has This Been Tested?
Pre-requisite: choose a testnet and get some testnet tokens !

1. Go to 'create contest' and go to 'Mint token'
2. Create a token with a max supply of `1`, and pick your address as the receiver
3. Create a contest
4. Go to the contest page
5. Submit a proposal and wait for votes to open (Current state [screenshot](https://imgur.com/a/7JJopeH))
6. Click on the vote button
7. In the input, type a number with decimals (like 0.01)
8. Click on 'Vote!'
9. Wait for the transaction to be successful 
10. Click on the vote button again
11. 'Available'  should displays  the accurate number of vote, and not a formatted rounded number anymore

Additionally, if the current user available number of votes is < 1, the displayed default number in the input won't be `1`, but the current user available number of votes.