### PR TITLE
bugfix: fix image/text not appearing when a proposal content has both

### DIFF
--- a/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
@@ -10,11 +10,17 @@ interface ProposalContentProps {
 }
 
 function renderContent(str: string) {
-  if (isUrlToImage(str)) return <img className="w-auto md:w-full h-auto" src={str} alt="" />;
+  let renderedContent = str
+  if (isUrlToImage(renderedContent)) {
+    str.match(/^https[^\?]*.(jpg|jpeg|gif|avif|webp|png|tiff|bmp)(\?(.*))?$/gim)?.map(img => {
+      renderedContent = renderedContent.replace(img, `<img class="w-auto md:w-full h-auto" src="${img}" alt="" />`)
+    })
+  };
+
   if (isUrlTweet(str)) {
     const tweetId =
       str.match(/^https?:\/\/twitter\.com\/(?:#!\/)?(\w+)\/status(es)?\/(\d+)$/) === null
-        ? new URL(str).pathname.split("/")[3]
+        ? new URL(renderedContent).pathname.split("/")[3]
         : //@ts-ignore
           str.match(/^https?:\/\/twitter\.com\/(?:#!\/)?(\w+)\/status(es)?\/(\d+)$/)[3];
     return (
@@ -28,7 +34,7 @@ function renderContent(str: string) {
   }
   return (
     <div className={`with-link-highlighted ${styles.content}`}>
-      <Interweave content={str} matchers={[new UrlMatcher("url")]} />
+      <Interweave content={renderedContent} matchers={[new UrlMatcher("url")]} />
     </div>
   );
 }


### PR DESCRIPTION
# Description

> UI doesn't display proposal content when it has both text and a link to an image

## Fix description

- Get the list of image links with a regex
- map the list of images link and `str.replace` each link with an image tag
- render the proposal content in Interweave

## Type of change

- [x] Bugfix (non-breaking)

# How Has This Been Tested?

Using contest `/polygon/0xd3eC630A5F86b45418db169fA0AA96283e9925DD`

1. Go the above contest page
2. Wait for the proposals to be loaded
3. You should now see text + images appearing together instead of nothing  in certain proposals

## Before
https://imgur.com/Eyp0kBV

## After 
https://imgur.com/SH0aWYp

---

| Future improvements: in the future when we integrate with TipTap, the component `ProposalContent` will  be completely reworked to make mixed content less tedious to render.
