### PR TITLE
ux fix: decrease prompt font size & add divider

### DIFF
--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -270,7 +270,7 @@ const LayoutViewContest = (props: any) => {
                   </h2>
 
                   {contestPrompt && (
-                    <p className="text-lg with-link-highlighted font-bold">
+                    <p className="text-base with-link-highlighted font-bold">
                       <Interweave content={contestPrompt} matchers={[new UrlMatcher("url")]} />
                     </p>
                   )}

--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -270,9 +270,10 @@ const LayoutViewContest = (props: any) => {
                   </h2>
 
                   {contestPrompt && (
-                    <p className="text-base with-link-highlighted font-bold">
+                    <p className="text-sm with-link-highlighted font-bold pb-8 border-b border-neutral-4">
                       <Interweave content={contestPrompt} matchers={[new UrlMatcher("url")]} />
                     </p>
+
                   )}
 
                   {contestStatus === CONTEST_STATUS.SNAPSHOT_ONGOING && (


### PR DESCRIPTION
# Description

> The prompt description is a tad bit too big. It would be nice for it to be smaller and to have a divider.

## Fix description

- Decrease the font size from `md` to `sm` + add a divider (border bottom + padding on the prompt description)
## Type of change

- [x] UX/UI Change (CSS only - non-breaking)

## Before
https://imgur.com/LBmNaaE

## After 
https://imgur.com/TLz5fME