### PR TITLE
uifix: reduce font size in send proposal dialog

### DIFF
--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
@@ -125,7 +125,7 @@ export const DialogModalSendProposal = (props: DialogModalSendProposalProps) => 
       contestStatus === CONTEST_STATUS.SUBMISSIONS_OPEN ? (
         <>
           {contestPrompt && (
-            <p className="mb-4 text-neutral-11 text-md font-bold with-link-highlighted ">
+            <p className="mb-4 text-neutral-12 leading-tight text-2xs font-medium with-link-highlighted">
               <Interweave content={contestPrompt} matchers={[new UrlMatcher("url")]} />
             </p>
           )}


### PR DESCRIPTION
# Description

> In the submit proposal modal, the prompt text is a bit too big and the grey colour is off putting.

## Fix description

- Decrease the font size from `md` to `2xs`
- Change text color to be closer to white 
- Change font-weight to be medium

This way, the prompt description will catch attention less while still being visible enough to the user. 

## Type of change
- [x] UX/UI Change (CSS only - non-breaking)

## Before
https://imgur.com/G2bjk5i

## After 
https://imgur.com/xHneUkK