### PR TITLE
bugfix: only parse as embedded tweet if the proposal is just a link to a tweet alone

### DIFF
--- a/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
@@ -17,21 +17,21 @@ function renderContent(str: string) {
     })
   };
 
-  // if (isUrlTweet(str)) {
-  //   const tweetId =
-  //     str.match(/^https?:\/\/twitter\.com\/(?:#!\/)?(\w+)\/status(es)?\/(\d+)$/) === null
-  //       ? new URL(renderedContent).pathname.split("/")[3]
-  //       : //@ts-ignore
-  //         str.match(/^https?:\/\/twitter\.com\/(?:#!\/)?(\w+)\/status(es)?\/(\d+)$/)[3];
-  //   return (
-  //     <>
-  //       <a target="_blank" rel="nofollow noreferrer" className="link mb-1 text-2xs" href={str}>
-  //         View on Twitter
-  //       </a>
-  //       <TwitterTweetEmbed tweetId={tweetId} options={{ theme: "dark", dnt: "true" }} />
-  //     </>
-  //   );
-  // }
+  if (isUrlTweet(str)) {
+    const tweetId =
+      str.match(/^https?:\/\/twitter\.com\/(?:#!\/)?(\w+)\/status(es)?\/(\d+)$/) === null
+        ? new URL(renderedContent).pathname.split("/")[3]
+        : //@ts-ignore
+          str.match(/^https?:\/\/twitter\.com\/(?:#!\/)?(\w+)\/status(es)?\/(\d+)$/)[3];
+    return (
+      <>
+        <a target="_blank" rel="nofollow noreferrer" className="link mb-1 text-2xs" href={str}>
+          View on Twitter
+        </a>
+        <TwitterTweetEmbed tweetId={tweetId} options={{ theme: "dark", dnt: "true" }} />
+      </>
+    );
+  }
   return (
     <div className={`with-link-highlighted ${styles.content}`}>
       <Interweave content={renderedContent} matchers={[new UrlMatcher("url")]} />

--- a/packages/react-app-revamp/helpers/isUrlTweet.ts
+++ b/packages/react-app-revamp/helpers/isUrlTweet.ts
@@ -1,6 +1,5 @@
 export function isUrlTweet(str: string) {
   return (
-    str.match(/^https?:\/\/twitter\.com\/(?:#!\/)?(\w+)\/status(es)?\/(\d+)$/) !== null ||
-    (str.includes("twitter.com/") && str.includes("/status/"))
+    str.match(/^https?:\/\/twitter\.com\/(?:#!\/)?(\w+)\/status(es)?\/(\d+)$/) !== null
   );
 }


### PR DESCRIPTION
# Description

> We were attempting to render urls as tweets that were not tweets. Closes #44.

## Fix description

- Only render urls as tweet embeds if the proposal is a link to a tweet and nothing more.

## Type of change

- [x] Bugfix (breaking)
