### PR TITLE
feat: allow contest viewing without connecting

### DIFF
--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -113,12 +113,7 @@ const LayoutViewContest = (props: any) => {
 
   useContestEvents();
   useEffect(() => {
-    if (chain?.id === chainId) {
       fetchContestInfo();
-    } else {
-      setIsLoading(false);
-      setIsListProposalsLoading(false);
-    }
   }, [chain?.id, chainId, asPath.split("/")[2], asPath.split("/")[3]]);
 
   useEffect(() => {
@@ -181,38 +176,17 @@ const LayoutViewContest = (props: any) => {
           />
         </div>
         <div className="md:pt-5 md:pb-20 flex flex-col md:col-span-8">
-          {account.isConnecting ||
-            account.isReconnecting ||
-            (chain?.id === chainId && (isLoading || isListProposalsLoading) && (
+          {
+            ((isLoading || isListProposalsLoading) && (
               <div className="animate-appear">
                 <Loader scale="page" />
               </div>
             ))}
 
-          {!account.isConnecting && !account.isReconnecting && !account?.address ? (
-            <p className="animate-appear font-bold text-center text-lg pt-10">
-              Please connect your account to view this contest.
-            </p>
-          ) : (
+          {
             <>
-              {chain?.id !== chainId && (
-                <div className="animate-appear flex text-center flex-col mt-10 mx-auto">
-                  <p className="font-bold text-lg">Looks like you&apos;re using the wrong network.</p>
-                  <p className="mt-2 mb-4 text-neutral-11 text-xs">
-                    You need to use {asPath.split("/")[2]} to check this contest.
-                  </p>
-                  <Button
-                    onClick={() => {
-                      switchNetwork?.(chainId);
-                    }}
-                    className="mx-auto"
-                  >
-                    Switch network
-                  </Button>
-                </div>
-              )}
 
-              {chain?.id === chainId && isError !== null && !isLoading && (
+              {isError !== null && !isLoading && (
                 <div className="my-6 md:my-0 animate-appear flex flex-col">
                   <div className="bg-negative-1 py-4 px-5 rounded-md border-solid border border-negative-4">
                     <p className="text-sm font-bold text-negative-10 text-center">
@@ -222,7 +196,7 @@ const LayoutViewContest = (props: any) => {
                   {isError === "CALL_EXCEPTION" ? (
                     <div className="animate-appear text-center my-3 space-y-3">
                       <p>
-                        Looks like this contract doesn&apos;t exist on {chain.name}. <br /> Try switching to another
+                        Looks like this contract doesn&apos;t exist on {chain?.name}. <br /> Try switching to another
                         network.
                       </p>
                     </div>
@@ -239,7 +213,7 @@ const LayoutViewContest = (props: any) => {
                 </div>
               )}
 
-              {chain?.id === chainId && isSuccess && isError === null && !isLoading && (
+              {isSuccess && isError === null && !isLoading && (
                 <div className="animate-appear pt-3 md:pt-0">
                   {pathname === ROUTE_CONTEST_PROPOSAL && (
                     <div>
@@ -344,7 +318,7 @@ const LayoutViewContest = (props: any) => {
                 </div>
               )}
             </>
-          )}
+          }
         </div>
       </div>
     </>


### PR DESCRIPTION
# Description

> Allow people to view contests when they don't have their wallets connected.

- Remove unnecessary checks on whether a user is connected for viewing a contest.

## Type of change

- [x] UI