### PR TITLE
feat: delete proposal

### DIFF
--- a/packages/react-app-revamp/components/_pages/DialogModalDeleteProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalDeleteProposal/index.tsx
@@ -1,0 +1,55 @@
+import shallow from "zustand/shallow";
+import Button from "@components/Button";
+import DialogModal from "@components/DialogModal";
+import TrackerDeployTransaction from "@components/TrackerDeployTransaction";
+import { useStore as useStoreDeleteProposal } from '@hooks/useDeleteProposal/store'
+import useDeleteProposal from "@hooks/useDeleteProposal";
+
+interface DialogDeleteProposalProps {
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+}
+
+export const DialogModalDeleteProposal = (props: DialogDeleteProposalProps) => {
+  const { transactionData } = useStoreDeleteProposal(
+    state => ({
+      //@ts-ignore
+      transactionData: state.transactionData,
+    }),
+    shallow,
+  );
+
+  const { deleteProposal , isLoading, isError, isSuccess} = useDeleteProposal()
+  return (
+    <DialogModal title="Delete this proposal" {...props}>
+      {(isSuccess === true || isLoading === true || isError === true) && (
+        <div className="animate-appear mt-2 mb-4">
+          <TrackerDeployTransaction isSuccess={isSuccess} isError={isError} isLoading={isLoading} />
+        </div>
+      )}
+
+      {isSuccess === true && transactionData?.transactionHref && (
+        <div className="my-2 animate-appear">
+          <a rel="nofollow noreferrer" target="_blank" href={transactionData?.transactionHref}>
+            View transaction <span className="link">here</span>
+          </a>
+        </div>
+      )}
+
+      {!isLoading && !isError && !isSuccess && <p className="animate-appear font-bold text-center mt-3 mb-6">
+         Are you sure you want to delete this submission ?
+      </p>}
+      <div className="mb-4 pt-2 animate-appear flex flex-col space-y-4 xs:flex-row xs:space-y-0 xs:space-i-3">
+        {!isSuccess && <Button disabled={isLoading} isLoading={isLoading} onClick={() => deleteProposal()}>
+          {isError ? "Try again" : "Yes, delete this proposal"}    
+        </Button>}
+        <Button disabled={isLoading} intent="neutral-outline" onClick={() => props.setIsOpen(false)}>
+          {isSuccess ? "Go back" : "Cancel"}
+        </Button>
+      </div>
+
+    </DialogModal>
+  );
+};
+
+export default DialogModalDeleteProposal;

--- a/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
@@ -21,6 +21,7 @@ export const ListProposals = () => {
   } = useRouter();
   const accountData = useAccount()
   const {
+    contestAuthorEthereumAddress,
     amountOfTokensRequiredToSubmitEntry,
     listProposalsData,
     currentUserAvailableVotesAmount,
@@ -29,6 +30,8 @@ export const ListProposals = () => {
     checkIfUserPassedSnapshotLoading,
   } = useStoreContest(
     state => ({
+      //@ts-ignore
+      contestAuthorEthereumAddress: state.contestAuthorEthereumAddress,
       //@ts-ignore
       contestStatus: state.contestStatus,
       //@ts-ignore
@@ -198,7 +201,7 @@ export const ListProposals = () => {
                         View proposal #{id}
                       </a>
                     </Link>
-                    {!isProposalDeleted(listProposalsData[id].content) && listProposalsData[id].authorEthereumAddress === accountData?.address && <button onClick={() => onClickProposalDelete(id)} className="w-full 2xs:w-auto mt-6 text-xs 2xs:text-2xs rounded-md py-1.5 2xs:py-1 px-3 relative z-20 bg-negative-4 hover:bg-opacity-50 focus:bg-opacity-75 text-negative-11 bg-opacity-40">
+                    {!isProposalDeleted(listProposalsData[id].content) && contestAuthorEthereumAddress === accountData?.address && <button onClick={() => onClickProposalDelete(id)} className="w-full 2xs:w-auto mt-6 text-xs 2xs:text-2xs rounded-md py-1.5 2xs:py-1 px-3 relative z-20 bg-negative-4 hover:bg-opacity-50 focus:bg-opacity-75 text-negative-11 bg-opacity-40">
                       <span className="font-bold">Delete this proposal</span>
                     </button>}
                   </div>

--- a/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
@@ -4,6 +4,7 @@ import { TwitterTweetEmbed } from "react-twitter-embed";
 import { Interweave } from "interweave";
 import { UrlMatcher } from "interweave-autolink";
 import styles from "./styles.module.css";
+import isProposalDeleted from "@helpers/isProposalDeleted";
 interface ProposalContentProps {
   content: string;
   author: string;
@@ -43,10 +44,13 @@ export const ProposalContent = (props: ProposalContentProps) => {
   const { content, author } = props;
   return (
     <>
-      <blockquote className="leading-relaxed">{renderContent(content)}</blockquote>
-      <figcaption className="pt-5 font-mono overflow-hidden text-neutral-12 text-ellipsis whitespace-nowrap">
+      <blockquote className={`
+        leading-relaxed
+        ${isProposalDeleted(content) ? "italic text-neutral-11" : ""}
+      `}>{renderContent(content)}</blockquote>
+      {!isProposalDeleted(content)  && <figcaption className="pt-5 font-mono overflow-hidden text-neutral-12 text-ellipsis whitespace-nowrap">
         — {author}
-      </figcaption>
+      </figcaption>}
     </>
   );
 };

--- a/packages/react-app-revamp/helpers/isProposalDeleted.ts
+++ b/packages/react-app-revamp/helpers/isProposalDeleted.ts
@@ -1,0 +1,5 @@
+export function isProposalDeleted(proposalContent: string): boolean {
+ return "This proposal has been deleted by the creator of the contest." === proposalContent
+}
+
+export default isProposalDeleted

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -184,7 +184,7 @@ export function useContest() {
         address: results[1],
         chainId: chain.mainnet.id,
       });
-      setContestAuthor(contestAuthorEns && contestAuthorEns !== null ? contestAuthorEns : results[1]);
+      setContestAuthor(contestAuthorEns && contestAuthorEns !== null ? contestAuthorEns : results[1], results[1]);
       setContestMaxNumberSubmissionsPerUser(results[2]);
       setContestMaxProposalCount(results[3]);
       setVotingTokenAddress(results[4]);

--- a/packages/react-app-revamp/hooks/useContest/store.ts
+++ b/packages/react-app-revamp/hooks/useContest/store.ts
@@ -7,6 +7,7 @@ export const createStore = () => {
   return create(set => ({
     contestName: null,
     contestPrompt: null,
+    contestAuthorEthereumAddress: null,
     contestAuthor: null,
     submissionsOpen: null,
     votesOpen: null,
@@ -43,7 +44,7 @@ export const createStore = () => {
       set({ contestMaxNumberSubmissionsPerUser: amount }),
     setContestStatus: (status: number) => set({ contestStatus: status }),
     setContestName: (name: string) => set({ contestName: name }),
-    setContestAuthor: (author: string) => set({ contestAuthor: author }),
+    setContestAuthor: (author: string, address: string) => set({ contestAuthor: author, contestAuthorEthereumAddress: address }),
     setSubmissionsOpen: (datetime: string) => set({ submissionsOpen: datetime }),
     setDidUserPassSnapshotAndCanVote: (isQualified: boolean) => set({ didUserPassSnapshotAndCanVote: isQualified }),
     setVotesOpen: (datetime: string) => set({ votesOpen: datetime }),

--- a/packages/react-app-revamp/hooks/useContest/store.ts
+++ b/packages/react-app-revamp/hooks/useContest/store.ts
@@ -94,5 +94,20 @@ export const createStore = () => {
           },
         },
       })),
+          //@ts-ignore
+    softDeleteProposal: (id) =>
+    set(state => ({
+      ...state,
+      listProposalsData: {
+        //@ts-ignore
+        ...state.listProposalsData,
+        [id]: {
+          //@ts-ignore
+          ...state.listProposalsData[id],
+          content: 'This proposal has been deleted by the creator of the contest.',
+          isContentImage: false,
+        },
+      },
+    })),
   }));
 };

--- a/packages/react-app-revamp/hooks/useContestEvents/index.ts
+++ b/packages/react-app-revamp/hooks/useContestEvents/index.ts
@@ -16,6 +16,8 @@ export function useContestEvents() {
     addProposalId,
     //@ts-ignore
     setProposalVotes,
+    //@ts-ignore,
+    softDeleteProposal,
   } = useStoreContest();
 
   useContractEvent({
@@ -47,6 +49,15 @@ export function useContestEvents() {
       updateProposalTransactionData(event[3].transactionHash, proposalId);
     },
   });
+
+  useContractEvent({
+    addressOrName: asPath.split("/")[3],
+    contractInterface: DeployedContestContract.abi,
+    eventName: "ProposalsDeleted",
+    listener: async event => {
+      softDeleteProposal(event[0].toString());
+    },
+  })
 
   useContractEvent({
     addressOrName: asPath.split("/")[3],

--- a/packages/react-app-revamp/hooks/useDeleteProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useDeleteProposal/index.ts
@@ -1,0 +1,101 @@
+import { waitForTransaction, writeContract } from "@wagmi/core";
+import { useRouter } from "next/router";
+import toast from "react-hot-toast";
+import { useNetwork } from "wagmi";
+import { useStore } from "./store";
+import DeployedContestContract from "@contracts/bytecodeAndAbi/Contest.sol/Contest.json";
+import { useEffect } from "react";
+
+export function useDeleteProposal() {
+  const { asPath } = useRouter()
+  const { chain } = useNetwork();
+  const {
+    //@ts-ignore
+    isModalOpen,
+    //@ts-ignore
+    isLoading,
+    //@ts-ignore
+    isError,
+    //@ts-ignore
+    error,
+    //@ts-ignore  
+    isSuccess,
+    //@ts-ignore   
+    transactionData,
+    //@ts-ignore    
+    setIsLoading,
+    //@ts-ignore
+    setIsSuccess,
+    //@ts-ignore
+    setIsError,
+    //@ts-ignore
+    setTransactionData,
+    //@ts-ignore
+    //@ts-ignore
+    pickedProposal,
+  } = useStore()
+
+  async function deleteProposal() {
+    const address = asPath.split("/")[3];
+
+    setIsLoading(true)
+    setIsLoading(true);
+    setIsSuccess(false);
+    setIsError(false, null);
+    setTransactionData(null);
+    const contractConfig = {
+      addressOrName: address,
+      contractInterface: DeployedContestContract.abi,
+    };
+    try {
+      const txCastVotes = await writeContract({
+        ...contractConfig,
+        functionName: "deleteProposals",
+        args: [[pickedProposal]],
+      });
+      const receipt = await waitForTransaction({
+        chainId: chain?.id,
+        //@ts-ignore
+        hash: txCastVotes.hash,
+      });
+      setTransactionData({
+        hash: receipt.transactionHash,
+        chainId: chain?.id,
+        //@ts-ignore
+        transactionHref: `${chain.blockExplorers?.default?.url}/tx/${txCastVotes?.hash}`,
+      });
+      setIsLoading(false);
+      setIsSuccess(true);
+      toast.success(`Proposal deleted successfully!`);
+    } catch (e) {
+      toast.error(
+        //@ts-ignore
+        e?.data?.message ?? "Something went wrong while deleting this proposal.",
+      );
+      console.error(e);
+      setIsLoading(false);
+      //@ts-ignore
+      setIsError(true, e?.data?.message ?? "Something went wrong while deleting this proposal.");
+    }
+  }
+
+  useEffect(() => {
+    if(isModalOpen === false) {
+        setIsLoading(false)
+        setIsSuccess(false)
+        setTransactionData({})
+        setIsError(false, null)
+    }
+  }, [isModalOpen])
+  
+  return {
+    deleteProposal,
+    isLoading,
+    isError,
+    error,
+    isSuccess,
+    transactionData,
+  }
+}
+
+export default useDeleteProposal

--- a/packages/react-app-revamp/hooks/useDeleteProposal/store.ts
+++ b/packages/react-app-revamp/hooks/useDeleteProposal/store.ts
@@ -1,0 +1,22 @@
+import create from "zustand";
+import createContext from "zustand/context";
+
+export const createStore = () => {
+  return create(set => ({
+    isLoading: false,
+    isError: false,
+    error: null,
+    isSuccess: false,
+    transactionData: null,
+    pickedProposal: null,
+    isModalOpen: false,
+    setIsModalOpen: (isOpen: boolean) => set({isModalOpen: isOpen}),
+    setPickedProposal: (id: any) => set({pickedProposal: id}),
+    setIsLoading: (value: boolean) => set({ isLoading: value }),
+    setIsSuccess: (value: boolean) => set({ isSuccess: value }),
+    setIsError: (isError: boolean, error: string | null) => set({ isError: isError, error, }),
+    setTransactionData: (data: any) => set({ transactionData: data }),
+  }));
+};
+
+export const { Provider, useStore } = createContext();

--- a/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
@@ -52,12 +52,12 @@ export function useSubmitProposal() {
         chainId: chain?.id,
         //@ts-ignore
         hash: txSendProposal.hash,
-        //@ts-ignore
-        transactionHref: `${chain.blockExplorers?.default?.url}/tx/${txSendProposal?.hash}`,
       });
       setTransactionData({
         chainId: chain?.id,
         hash: receipt.transactionHash,
+        //@ts-ignore
+        transactionHref: `${chain.blockExplorers?.default?.url}/tx/${txSendProposal?.hash}`,
       });
       setIsLoading(false);
       setIsSuccess(true);

--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import shallow from "zustand/shallow";
 import { useRouter } from "next/router";
 import Link from "next/link";
-import { useAccount, useNetwork, useSwitchNetwork } from "wagmi";
+import { useAccount, useNetwork } from "wagmi";
 import { isAfter, isBefore, isDate } from "date-fns";
 import { ArrowLeftIcon } from "@heroicons/react/solid";
 import {
@@ -30,6 +30,13 @@ import {
   Provider as ProviderCastVotes,
   createStore as createStoreCastVotes,
 } from "@hooks/useCastVotes/store";
+
+import {
+  useStore as useStoreDeleteProposal,
+  Provider as ProviderDeleteProposal,
+  createStore as createStoreDeleteProposal,
+} from "@hooks/useDeleteProposal/store";
+
 import { Interweave } from "interweave";
 import { UrlMatcher } from "interweave-autolink";
 import { useContest } from "@hooks/useContest";
@@ -45,21 +52,19 @@ import { chains } from "@config/wagmi";
 import { CONTEST_STATUS } from "@helpers/contestStatus";
 import Sidebar from "./Sidebar";
 import useCheckSnapshotProgress from "./Timeline/Countdown/useCheckSnapshotProgress";
+import DialogModalDeleteProposal from "@components/_pages/DialogModalDeleteProposal";
 
 const LayoutViewContest = (props: any) => {
   const { children } = props;
   const { query, asPath, pathname, push } = useRouter();
   const account = useAccount();
   const { chain } = useNetwork();
-  const { switchNetwork } = useSwitchNetwork();
 
   const {
     isLoading,
     address,
     fetchContestInfo,
     checkIfCurrentUserQualifyToVote,
-    setIsLoading,
-    setIsListProposalsLoading,
     isListProposalsLoading,
     isSuccess,
     isError,
@@ -110,6 +115,7 @@ const LayoutViewContest = (props: any) => {
   const [isTimelineModalOpen, setIsTimelineModalOpen] = useState(false);
   const stateSubmitProposal = useStoreSubmitProposal();
   const stateCastVotes = useStoreCastVotes();
+  const stateDeleteProposasl = useStoreDeleteProposal();
 
   useContestEvents();
   useEffect(() => {
@@ -300,7 +306,16 @@ const LayoutViewContest = (props: any) => {
                         setIsOpen={stateSubmitProposal.setIsModalOpen}
                       />
                     )}
-
+                  {!isLoading &&
+                    isSuccess &&
+                    chain?.id === chainId &&
+                    <DialogModalDeleteProposal
+                      /* @ts-ignore */
+                      isOpen={stateDeleteProposasl.isModalOpen}
+                      /* @ts-ignore */
+                      setIsOpen={stateDeleteProposasl.setIsModalOpen}
+                    />
+                  }
                   {!isLoading &&
                     isSuccess &&
                     chain?.id === chainId &&
@@ -330,7 +345,9 @@ export const getLayout = (page: any) => {
     <ProviderContest createStore={createStoreContest}>
       <ProviderSubmitProposal createStore={createStoreSubmitProposal}>
         <ProviderCastVotes createStore={createStoreCastVotes}>
-          <LayoutViewContest>{page}</LayoutViewContest>
+          <ProviderDeleteProposal createStore={createStoreDeleteProposal}>
+            <LayoutViewContest>{page}</LayoutViewContest>
+          </ProviderDeleteProposal>
         </ProviderCastVotes>
       </ProviderSubmitProposal>
     </ProviderContest>,

--- a/packages/react-app-revamp/pages/contest/[chain]/[address]/proposal/[proposal].tsx
+++ b/packages/react-app-revamp/pages/contest/[chain]/[address]/proposal/[proposal].tsx
@@ -11,6 +11,7 @@ import ListProposalVotes from '@components/_pages/ListProposalVotes'
 import { CONTEST_STATUS } from '@helpers/contestStatus'
 import type { NextPage } from 'next'
 import Button from '@components/Button'
+import isProposalDeleted from '@helpers/isProposalDeleted'
 
 interface PageProps {
   address: string,
@@ -66,7 +67,7 @@ const Page: NextPage = (props: PageProps) => {
           author={listProposalsData[proposal]?.author}
           content={listProposalsData[proposal]?.content}
         />
-        {contestStatus === CONTEST_STATUS.VOTING_OPEN && proposal && proposal !== null && <div className='flex flex-col items-center justify-center mt-10'>
+        {contestStatus === CONTEST_STATUS.VOTING_OPEN && proposal && proposal !== null && !isProposalDeleted(listProposalsData[proposal]?.content) && <div className='flex flex-col items-center justify-center mt-10'>
 
         <Button 
           isLoading={checkIfUserPassedSnapshotLoading}


### PR DESCRIPTION
# Description

- Add delete proposal button on proposal list
- Add delete proposal modal

## Type of change

- [x] New feature (breaking change)

# How Has This Been Tested?

Scenario 1: contest creator
1. Go to a contest you created
2. On each non-deleted proposal, you should see a delete button
3. Click on the delete button
4. The delete proposal modal should appear
5. If you click on cancel, the modal should close
6. In the delete modal, click on 'Yes, delete'
7.Sign the transaction in your wallet
8. When the transaction is successful, a link to the transaction on the explorer should appear + a go back button
9. Click on go back
10. The modal should be closed. The proposal you just deleted should display 'This proposal has been deleted by the creator of this contest'
11. If votes are still open, voting should be disabled for this proposal

Scenario 2: not the contest creator
You shouldn't be able to see the delete button

--- 

# Screenshots

![Screenshot_20220811_200736](https://user-images.githubusercontent.com/15010369/184215353-79c8eac9-d657-4ed4-9947-58d877921077.png)
![Screenshot_20220811_200818](https://user-images.githubusercontent.com/15010369/184215402-c991713d-06b8-43d3-92cf-e57458c9
![Screenshot_20220811_200319](https://user-images.githubusercontent.com/15010369/184215445-7063d0fc-dd0a-41b5-ad46-2ed99c5051ec.png)
270f.png)
![Screenshot_20220811_195654](https://user-images.githubusercontent.com/15010369/184215484-f5affe46-699b-46a7-8ffc-f57cf5dfbb3a.png)
![Screenshot_20220811_200642](https://user-images.githubusercontent.com/15010369/184215532-8f2559f5-c341-41d5-b5e9-d48df4c67325.png)
![Screenshot_20220811_200701](https://user-images.githubusercontent.com/15010369/184215561-db68a3e6-dd8a-446e-83d4-15f3d311d55f.png)



