### PR TITLE
bugfix: fix cap proposal submission check

### DIFF
--- a/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
@@ -29,10 +29,13 @@ export const ListProposals = () => {
     didUserPassSnapshotAndCanVote,
     checkIfUserPassedSnapshotLoading,
     downvotingAllowed,
+    listProposalsIds,
   } = useStoreContest(
     state => ({
       //@ts-ignore
       downvotingAllowed: state.downvotingAllowed,
+      //@ts-ignore
+      listProposalsIds: state.listProposalsIds,
       //@ts-ignore
       contestAuthorEthereumAddress: state.contestAuthorEthereumAddress,
       //@ts-ignore
@@ -101,7 +104,7 @@ export const ListProposals = () => {
       );
     }
     // Empty state
-    if (Object.keys(listProposalsData).length === 0) {
+    if (listProposalsIds.length === 0) {
       return (
         <div className="flex flex-col text-center items-center">
           <p className="text-neutral-9 italic mb-6">
@@ -112,7 +115,8 @@ export const ListProposals = () => {
           </p>
           {/* @ts-ignore */}
           {contestStatus === CONTEST_STATUS.SUBMISSIONS_OPEN &&
-            currentUserAvailableVotesAmount >= amountOfTokensRequiredToSubmitEntry && (
+            currentUserAvailableVotesAmount >= amountOfTokensRequiredToSubmitEntry && 
+            (
               //@ts-ignore
               <Button onClick={() => stateSubmitProposal.setIsModalOpen(true)}>Submit a proposal</Button>
             )}
@@ -132,7 +136,7 @@ export const ListProposals = () => {
             .map((id, i) => {
               return (
                 <li
-                  className={`${styles.listElement} px-5 pt-5 pb-3 rounded-md 2xs:rounded-none 2xs:p-0 border border-solid border-neutral-1 2xs:border-0 relative overflow-hidden text-sm ${styles.wrapper}`}
+                  className={`${styles.listElement} animate-appear px-5 pt-5 pb-3 rounded-md 2xs:rounded-none 2xs:p-0 border border-solid border-neutral-1 2xs:border-0 relative overflow-hidden text-sm ${styles.wrapper}`}
                   key={id}
                 >
                   <div className="text-center 2xs:border-is-4 border-solid border-neutral-1 2xs:border-neutral-5 flex flex-col 2xs:items-center pt-2 2xs:pt-0">

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -78,7 +78,7 @@ export function useContest() {
     //@ts-ignore
     setContestMaxProposalCount,
     //@ts-ignore
-    setCurrentUserProposalCount,
+    increaseCurrentUserProposalCount,
     //@ts-ignore
     setUsersQualifyToVoteIfTheyHoldTokenAtTime,
     //@ts-ignore
@@ -384,8 +384,7 @@ export function useContest() {
     // (Needed to track if the current user can submit a proposal)
     //@ts-ignore
     if (data[0] === accountData?.address) {
-      let tempCount = currentUserProposalCount;
-      setCurrentUserProposalCount(tempCount++);
+      increaseCurrentUserProposalCount();
     }
     setProposalData({ id: proposalsIdsRawData[i], data: proposalData });
   }

--- a/packages/react-app-revamp/layouts/LayoutViewContest/Sidebar/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/Sidebar/index.tsx
@@ -33,6 +33,7 @@ export const Sidebar = (props: any) => {
   } = props;
 
   const {
+    listProposalsData,
     amountOfTokensRequiredToSubmitEntry,
     currentUserAvailableVotesAmount,
     listProposalsIds,
@@ -45,6 +46,8 @@ export const Sidebar = (props: any) => {
     contestStatus,
   } = useStoreContest(
     state => ({
+      //@ts-ignore
+      listProposalsData: state.listProposalsData,
       //@ts-ignore
       contestStatus: state.contestStatus,
       //@ts-ignore
@@ -68,7 +71,6 @@ export const Sidebar = (props: any) => {
     }),
     shallow,
   );
-
   const stateSubmitProposal = useStoreSubmitProposal();
 
   return (
@@ -148,6 +150,7 @@ export const Sidebar = (props: any) => {
                 : "primary"
             }
             disabled={
+              listProposalsIds.length > Object.keys(listProposalsData).length || 
               currentUserAvailableVotesAmount < amountOfTokensRequiredToSubmitEntry ||
               currentUserProposalCount >= contestMaxNumberSubmissionsPerUser ||
               listProposalsIds.length >= contestMaxProposalCount ||


### PR DESCRIPTION
# Description

>  After submitting a proposal, the UI makes it appear as if the user can submit more proposal when they can't

Possible regression bug.
Should close #50

## Fix description

- use `increaseCurrentUserProposalCount` instead of `setCurrentUserProposalCount` in `fetchProposal` (otherwise the proposal count isn't updated)
- use proper comparisons to determine if the user can submit another proposal : compare  `listProposalsIds.length` and `listProposalsRawData.length` to know if proposals list has finished loading ; if so, if `currentUserProposalCount` < `contestMaxNumberSubmissionsPerUser` and `contestMaxProposalCount` < `listProposalsIds.length`, the user can add another proposal ; otherwise, the button is disabled.


## Type of change

- [x] Bugfix (non-breaking)

## How was this tested

[Video](https://www.loom.com/share/a81a8d59c82f4d9dbbc94108eb3a5a50)

1. Create a contest (in our test case, 2 proposals max)
2. Go to contest, page
3. You should see 2 enabled 'submit proposal' buttons  one in the sidebar, another where the list of proposals should be showing.
4. The 'Submit proposal' dialog should open.  Submit a proposal and sign the transaction in your wallet
5. Once the transaction is successful, the 'Submit proposal' dialog should display a button that says 'submit another proposal' ; if you close the modal, in the sidebar, the 'submit proposal' button should still be enabled.
6. Submit another proposal and sign the transaction in your wallet
7. Once the transaction is successful, the 'Submit proposal' dialog should display the following message "You can't submit more proposals". 
8. Close the modal
9. In the sidebar, the "Submit proposal" button should be disabled and outlined.
10. Reload the page
11. The "Submit proposal" button should still be disabled. 


