### PR TITLE
bugfix: await loading before rendering proposals

### DIFF
--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
@@ -121,7 +121,7 @@ export const DialogModalSendProposal = (props: DialogModalSendProposalProps) => 
 
       {currentUserAvailableVotesAmount >= amountOfTokensRequiredToSubmitEntry &&
       currentUserProposalCount < contestMaxNumberSubmissionsPerUser &&
-      listProposalsIds?.length < contestMaxProposalCount &&
+      listProposalsIds.length < contestMaxProposalCount &&
       contestStatus === CONTEST_STATUS.SUBMISSIONS_OPEN ? (
         <>
           {contestPrompt && (
@@ -162,7 +162,7 @@ export const DialogModalSendProposal = (props: DialogModalSendProposalProps) => 
                   </div>
                 </FormField>
                 <Button
-                  disabled={proposal?.trim()?.length === 0 || isLoading}
+                  disabled={proposal.trim().length === 0 || isLoading}
                   type="submit"
                   className={isLoading || error !== null ? "hidden" : "mt-3"}
                 >

--- a/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
@@ -104,7 +104,7 @@ export const ListProposals = () => {
       );
     }
     // Empty state
-    if (listProposalsIds?.length === 0) {
+    if (listProposalsIds.length === 0) {
       return (
         <div className="flex flex-col text-center items-center">
           <p className="text-neutral-9 italic mb-6">

--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/StepIndicator/index.tsx
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/StepIndicator/index.tsx
@@ -22,7 +22,7 @@ export const stepsNames = {
   },
 };
 
-const stepsNumber = Object.keys(stepsNames)?.length;
+const stepsNumber = Object.keys(stepsNames).length;
 export const StepIndicator = () => {
   const { currentStep, setCurrentStep } = useStore(
     state => ({

--- a/packages/react-app-revamp/helpers/getContestContractVersion.ts
+++ b/packages/react-app-revamp/helpers/getContestContractVersion.ts
@@ -9,12 +9,12 @@ export async function getContestContractVersion(address: string) {
   const provider = await getProvider();
   const bytecode = await provider.getCode(address);
 
-  if (bytecode?.length <= 2) return null;
-  if (!bytecode?.includes(utils.id("prompt()").slice(2, 10))) {
+  if (bytecode.length <= 2) return null;
+  if (!bytecode.includes(utils.id("prompt()").slice(2, 10))) {
     return LegacyDeployedContestContract.abi;
-  } else if (!bytecode?.includes(utils.id("allProposalTotalVotes()").slice(2, 10))) {
+  } else if (!bytecode.includes(utils.id("allProposalTotalVotes()").slice(2, 10))) {
     return PromptDeployedContestContract.abi;
-  } else if (!bytecode?.includes(utils.id("downvotingAllowed()").slice(2, 10))) {
+  } else if (!bytecode.includes(utils.id("downvotingAllowed()").slice(2, 10))) {
     return AllProposalTotalVotesDeployedContestContract.abi;
   }
   

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -173,14 +173,14 @@ export function useContest() {
         },
       ];
       //@ts-ignore
-      if (abi?.filter(el => el.name === "prompt")?.length > 0) {
+      if (abi?.filter(el => el.name === "prompt").length > 0) {
         contracts.push({
           ...contractConfig,
           functionName: "prompt",
         });
       }
       //@ts-ignore
-      if (abi?.filter(el => el.name === "downvotingAllowed")?.length > 0) {
+      if (abi?.filter(el => el.name === "downvotingAllowed").length > 0) {
         contracts.push({
           ...contractConfig,
           functionName: "downvotingAllowed",
@@ -189,14 +189,14 @@ export function useContest() {
 
       const results = await readContracts({ contracts });
       //@ts-ignore
-      if (abi?.filter(el => el.name === "prompt")?.length > 0) {
+      if (abi?.filter(el => el.name === "prompt").length > 0) {
         //@ts-ignore
-        const indexToCheck = abi?.filter(el => el.name === "downvotingAllowed")?.length > 0 ? 2 : 1;
-        setContestPrompt(results[contracts?.length - indexToCheck]);
+        const indexToCheck = abi?.filter(el => el.name === "downvotingAllowed").length > 0 ? 2 : 1;
+        setContestPrompt(results[contracts.length - indexToCheck]);
       }
       //@ts-ignore
-      if (abi?.filter(el => el.name === "downvotingAllowed")?.length > 0) {
-        const isAllowed = parseInt(`${results[contracts?.length - 1]}`) === 1 ? true : false;
+      if (abi?.filter(el => el.name === "downvotingAllowed").length > 0) {
+        const isAllowed = parseInt(`${results[contracts.length - 1]}`) === 1 ? true : false;
         setDownvotingAllowed(isAllowed);
       } else {
         setDownvotingAllowed(false);
@@ -441,7 +441,7 @@ export function useContest() {
 
         const results = await readContracts({ contracts });
 
-        for (let i = 0; i < proposalsIdsRawData?.length; i++) {
+        for (let i = 0; i < proposalsIdsRawData.length; i++) {
           // For all proposals, fetch
           fetchProposal(i, results, proposalsIdsRawData);
         }

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -413,6 +413,7 @@ export function useContest() {
     };
     const contractBaseOptions = {};
     try {
+      setIsListProposalsLoading(true);
       // Get list of proposals (ids)
       const proposalsIdsRawData = await readContract({
         ...contractConfig,
@@ -441,10 +442,12 @@ export function useContest() {
 
         const results = await readContracts({ contracts });
 
+        var proposalFetchPromises = [];
         for (let i = 0; i < proposalsIdsRawData.length; i++) {
           // For all proposals, fetch
-          fetchProposal(i, results, proposalsIdsRawData);
+          proposalFetchPromises.push(fetchProposal(i, results, proposalsIdsRawData));
         }
+        await Promise.all(proposalFetchPromises);
       }
       setIsLoading(false);
       setIsListProposalsLoading(false);

--- a/packages/react-app-revamp/hooks/useExportContestDataToCSV/useExportContestDataToCSV.ts
+++ b/packages/react-app-revamp/hooks/useExportContestDataToCSV/useExportContestDataToCSV.ts
@@ -82,10 +82,10 @@ export function useExportContestDataToCSV() {
     stateExportData.setError(null, false);
 
     const propArrayToReturn = [];
-    const tenthPercentile = Math.ceil(listProposalsIds?.length / 10);
+    const tenthPercentile = Math.ceil(listProposalsIds.length / 10);
     const ensNamesMap = new Map();
     try {
-      for (let i = 0; i < listProposalsIds?.length; i++) {
+      for (let i = 0; i < listProposalsIds.length; i++) {
         const propId = listProposalsIds[i];
         const propTotalVotes = listProposalsData[propId].votes;
         const propContent = listProposalsData[propId].content;
@@ -109,7 +109,7 @@ export function useExportContestDataToCSV() {
         };
 
         //@ts-ignore
-        if (addressesVoted?.length == 0) {
+        if (addressesVoted.length == 0) {
           const noVoterDict = {
             ...COMMON_DATA,
             [HEADERS_KEYS.VOTER]: "No voters",
@@ -127,7 +127,7 @@ export function useExportContestDataToCSV() {
         }
 
         //@ts-ignore
-        for (let j = 0; j < addressesVoted?.length; j++) {
+        for (let j = 0; j < addressesVoted.length; j++) {
           //@ts-ignore
           const address = addressesVoted[j];
           const addressPropVote = await fetchVotesPerAddress(propId, address);
@@ -163,11 +163,11 @@ export function useExportContestDataToCSV() {
         }
 
         if (i % tenthPercentile == 0) {
-          stateExportData.setLoadingMessage(`Loading ${i} of ${listProposalsIds?.length} entries...`);
+          stateExportData.setLoadingMessage(`Loading ${i} of ${listProposalsIds.length} entries...`);
         }
       }
 
-      stateExportData.setLoadingMessage(`Loaded ${listProposalsIds?.length} out of ${listProposalsIds?.length} entries!`);
+      stateExportData.setLoadingMessage(`Loaded ${listProposalsIds.length} out of ${listProposalsIds.length} entries!`);
       stateExportData.setCsv(propArrayToReturn);
       stateExportData.setIsSuccess(true);
       stateExportData.setIsLoading(false);

--- a/packages/react-app-revamp/layouts/LayoutViewContest/Sidebar/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/Sidebar/index.tsx
@@ -139,7 +139,7 @@ export const Sidebar = (props: any) => {
             intent={
               currentUserAvailableVotesAmount < amountOfTokensRequiredToSubmitEntry ||
               currentUserProposalCount >= contestMaxNumberSubmissionsPerUser ||
-              listProposalsIds?.length >= contestMaxProposalCount ||
+              listProposalsIds.length >= contestMaxProposalCount ||
               contestStatus !== CONTEST_STATUS.SUBMISSIONS_OPEN ||
               isLoading ||
               isListProposalsLoading ||
@@ -150,10 +150,10 @@ export const Sidebar = (props: any) => {
                 : "primary"
             }
             disabled={
-              listProposalsIds?.length > Object.keys(listProposalsData)?.length || 
+              listProposalsIds.length > Object.keys(listProposalsData).length || 
               currentUserAvailableVotesAmount < amountOfTokensRequiredToSubmitEntry ||
               currentUserProposalCount >= contestMaxNumberSubmissionsPerUser ||
-              listProposalsIds?.length >= contestMaxProposalCount ||
+              listProposalsIds.length >= contestMaxProposalCount ||
               contestStatus !== CONTEST_STATUS.SUBMISSIONS_OPEN ||
               isLoading ||
               isListProposalsLoading ||


### PR DESCRIPTION
# Description

This PR fixes a race condition I created in [this commit](https://github.com/JokeDAO/JokeDaoV2Dev/commit/582c0ce9523edba5cc90c135441128be90db2bcb) by deleting `setIsListProposalsLoading(true);` in `fetchAllProposals()`.

What has been happening since then is that we try to load a page before we get the necessary data from the RPC endpoints. That explains why the "can't access length of `undefined` error we've been seeing only happens when a ton of people were using the endpoint: when the endpoint isn't getting hammered, proposal data requests return before we attempt to render proposal data, but when it is and latency goes up by even a bit, we try to render data before it loads and errored out (we are attempting to access a member of `undefined` because the proposal data hadn't loaded yet as shown in the error messages below)!

I also reverted a commit I made adding optional checks to where we check length because that really just adds complexity to debugging.

This PR addresses #39, hopefully completely (adding paid endpoints and stopping this race condition should prevent this bug but as to not jinx it let's wait to see if there isn't something else that crops up before closing the issue).

## Type of change

- [x] Bugfix (breaking)

<img width="708" alt="Screen Shot 2022-08-19 at 12 20 16 PM" src="https://user-images.githubusercontent.com/27874039/185689425-36f7f775-d0ff-4c08-8bec-c0f1c4844253.png">

<img width="399" alt="Screen Shot 2022-08-19 at 12 24 41 PM" src="https://user-images.githubusercontent.com/27874039/185689507-328fad34-26eb-424b-bd55-5f911e7e8372.png">