### PR TITLE
bugfix: access other chains without connecting

### DIFF
--- a/packages/react-app-revamp/helpers/getContestContractVersion.ts
+++ b/packages/react-app-revamp/helpers/getContestContractVersion.ts
@@ -4,9 +4,12 @@ import PromptDeployedContestContract from "@contracts/bytecodeAndAbi/Contest.leg
 import AllProposalTotalVotesDeployedContestContract from "@contracts/bytecodeAndAbi/Contest.legacy.3.allProposalTotalVotes.sol/Contest.json";
 import { getProvider } from "@wagmi/core";
 import { utils } from "ethers";
+import { chains } from "@config/wagmi";
 
-export async function getContestContractVersion(address: string) {
-  const provider = await getProvider();
+export async function getContestContractVersion(address: string, chainName: string) {
+  const chainId = chains
+      .filter(chain => chain.name.toLowerCase().replace(" ", "") === chainName)?.[0]?.id;;
+  const provider = await getProvider({chainId: chainId});
   const bytecode = await provider.getCode(address);
 
   if (bytecode.length <= 2) return null;

--- a/packages/react-app-revamp/hooks/useCastVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useCastVotes/index.ts
@@ -35,7 +35,8 @@ export function useCastVotes() {
 
   async function castVotes(amount: number, isPositive: boolean) {
     const address = asPath.split("/")[3];
-    const abi = await getContestContractVersion(address);
+    const chainName = asPath.split("/")[2];
+    const abi = await getContestContractVersion(address, chainName);
     setIsLoading(true);
     setIsSuccess(false);
     setError(null);

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -16,10 +16,11 @@ export function useContest() {
   const { indexContest } = useContestsIndex();
   const provider = useProvider();
   const { asPath } = useRouter();
-  const [chainId, setChaindId] = useState(
+  const [chainId, setChainId] = useState(
     chains.filter(chain => chain.name.toLowerCase().replace(" ", "") === asPath.split("/")[2])?.[0]?.id,
   );
   const [address, setAddress] = useState(asPath.split("/")[3]);
+  const [chainName, setChainName] = useState(asPath.split("/")[2]);
   const {
     //@ts-ignore
     setContestName,
@@ -104,7 +105,7 @@ export function useContest() {
   async function fetchContestInfo() {
     setIsLoading(true);
     setIsListProposalsLoading(true);
-    const abi = await getContestContractVersion(address);
+    const abi = await getContestContractVersion(address, chainName);
     if (abi === null) {
       toast.error("This contract doesn't exist on this chain.");
       setIsError("This contract doesn't exist on this chain.");
@@ -118,6 +119,7 @@ export function useContest() {
     const contractConfig = {
       addressOrName: address,
       contractInterface: abi,
+      chainId: chainId,
     };
     try {
       const contracts = [
@@ -296,7 +298,7 @@ export function useContest() {
   }
 
   async function checkIfCurrentUserQualifyToVote() {
-    const abi = await getContestContractVersion(address);
+    const abi = await getContestContractVersion(address, chainName);
     if (abi === null) {
       toast.error("This contract doesn't exist on this chain.");
       setIsError("This contract doesn't exist on this chain.");
@@ -311,6 +313,7 @@ export function useContest() {
     const contractConfig = {
       addressOrName: address,
       contractInterface: abi,
+      chainId: chainId,
     };
     const contractBaseOptions = {};
     setCheckIfUserPassedSnapshotLoading(true);
@@ -395,7 +398,7 @@ export function useContest() {
   }
 
   async function fetchAllProposals() {
-    const abi = await getContestContractVersion(address);
+    const abi = await getContestContractVersion(address, chainName);
     if (abi === null) {
       toast.error("This contract doesn't exist on this chain.");
       setIsError("This contract doesn't exist on this chain.");
@@ -410,6 +413,7 @@ export function useContest() {
     const contractConfig = {
       addressOrName: address,
       contractInterface: abi,
+      chainId: chainId,
     };
     const contractBaseOptions = {};
     try {
@@ -468,7 +472,7 @@ export function useContest() {
   }
 
   async function updateCurrentUserVotes() {
-    const abi = await getContestContractVersion(address);
+    const abi = await getContestContractVersion(address, chainName);
     if (abi === null) {
       toast.error("This contract doesn't exist on this chain.");
       setIsError("This contract doesn't exist on this chain.");
@@ -483,6 +487,7 @@ export function useContest() {
     const contractConfig = {
       addressOrName: address,
       contractInterface: abi,
+      chainId: chainId,
     };
 
     try {
@@ -528,7 +533,7 @@ export function useContest() {
     setIsLoading,
     setIsListProposalsLoading,
     chainId,
-    setChaindId,
+    setChainId,
     fetchAllProposals,
     isLoading,
     isListProposalsLoading,

--- a/packages/react-app-revamp/hooks/useDeleteProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useDeleteProposal/index.ts
@@ -38,7 +38,8 @@ export function useDeleteProposal() {
 
   async function deleteProposal() {
     const address = asPath.split("/")[3];
-    const abi = await getContestContractVersion(address);
+    const chainName = asPath.split("/")[2];
+    const abi = await getContestContractVersion(address, chainName);
     setIsLoading(true)
     setIsLoading(true);
     setIsSuccess(false);

--- a/packages/react-app-revamp/hooks/useExportContestDataToCSV/useExportContestDataToCSV.ts
+++ b/packages/react-app-revamp/hooks/useExportContestDataToCSV/useExportContestDataToCSV.ts
@@ -27,7 +27,8 @@ export function useExportContestDataToCSV() {
     const url = asPath.split("/");
     const chainId = chains.filter(chain => chain.name.toLowerCase().replace(" ", "") === url[2])?.[0]?.id;
     const address = url[3];
-    const abi = await getContestContractVersion(address);
+    const chainName = url[2];
+    const abi = await getContestContractVersion(address, chainName);
     if (abi === null) {
       return;
     }
@@ -35,6 +36,7 @@ export function useExportContestDataToCSV() {
       const contractConfig = {
         addressOrName: address,
         contractInterface: abi,
+        chainId: chainId,
       };
       //@ts-ignore
       const list = await readContract({
@@ -53,7 +55,8 @@ export function useExportContestDataToCSV() {
     const url = asPath.split("/");
     const chainId = chains.filter(chain => chain.name.toLowerCase().replace(" ", "") === url[2])?.[0]?.id;
     const address = url[3];
-    const abi = await getContestContractVersion(address);
+    const chainName = url[2];
+    const abi = await getContestContractVersion(address, chainName);
     if (abi === null) {
       return;
     }

--- a/packages/react-app-revamp/hooks/useProposalVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useProposalVotes/index.ts
@@ -61,7 +61,8 @@ export function useProposalVotes(id: number | string) {
 
   async function fetchProposalVotes() {
     setIsListVotersLoading(true);
-    const abi = await getContestContractVersion(address);
+    const chainName = url[2];
+    const abi = await getContestContractVersion(address, chainName);
     if (abi === null) {
       setIsListVotersLoading(false);
       setIsListVotersError("This contract doesn't exist on this chain.");
@@ -74,6 +75,7 @@ export function useProposalVotes(id: number | string) {
       const contractConfig = {
         addressOrName: address,
         contractInterface: abi,
+        chainId: chainId,
       };
       const list = await readContract({
         ...contractConfig,

--- a/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
@@ -34,7 +34,8 @@ export function useSubmitProposal() {
 
   async function sendProposal(proposalContent: string) {
     const address = asPath.split("/")[3];
-    const abi = await getContestContractVersion(address);
+    const chainName = asPath.split("/")[2];
+    const abi = await getContestContractVersion(address, chainName);
     setIsLoading(true);
     setIsSuccess(false);
     setError(null);

--- a/packages/react-app-revamp/layouts/LayoutViewContest/Timeline/Countdown/useCheckSnapshotProgress.ts
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/Timeline/Countdown/useCheckSnapshotProgress.ts
@@ -28,7 +28,8 @@ export function useCheckSnapshotProgress() {
 
   async function updateSnapshotProgress() {
     const address = asPath.split("/")[3];
-    const abi = await getContestContractVersion(address);
+    const chainName = asPath.split("/")[2];
+    const abi = await getContestContractVersion(address, chainName);
     while (isSnaspshotTaken !== true) {
       const statusRawData = await readContract({
         addressOrName: address,

--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -74,7 +74,7 @@ const LayoutViewContest = (props: any) => {
     retry,
     onSearch,
     chainId,
-    setChaindId,
+    setChainId,
   } = useContest();
 
   const {
@@ -145,7 +145,7 @@ const LayoutViewContest = (props: any) => {
     if (account?.connector) {
       account?.connector.on("change", data => {
         //@ts-ignore
-        setChaindId(data.chain.id);
+        setChainId(data.chain.id);
       });
     }
   }, [account?.connector]);


### PR DESCRIPTION
# Description

Bug Description: Introduced in #46, the viewing of contests without having a user's wallet connected is only possible on Polygon because that is the chain that the WAGMI library hooks default to if they are not explicitly given a chainId to make calls to (they use the first in the list of chains that they have). This is meant to be possible on any chain that jokedao.io supports.

Fix Description: To fix this, this PR just adds chain information from the url of a link to function calls to get the ABI of a contest as well as those that are made reading contests so that they are run against the correct chain.

## Type of change

- [x] Bugfix (non-breaking)

# How Has This Been Tested?
- Going to a link contest on a chain other than Polygon ([this one](https://www.jokedao.io/contest/optimism/0x1e4D52b5FfD9Cc8B7c4f5d3c2acCB49E60Da51b6) for example) without one's wallet connected results in it being rendered as opposed to what happens now which is that it errors out as seen in the below screenshot.

<img width="908" alt="Screen Shot 2022-08-24 at 2 00 46 AM" src="https://user-images.githubusercontent.com/27874039/186342018-05a7a816-a751-4bac-9e83-29234a5b2676.png">