### PR TITLE
bugfix: contest rules creation form inputs

### DIFF
--- a/packages/react-app-revamp/components/FormRadioOption/index.tsx
+++ b/packages/react-app-revamp/components/FormRadioOption/index.tsx
@@ -4,11 +4,11 @@ export const FormRadioOption = (props: any) => {
   return (
     <RadioGroup.Option className={`${props.disabled ? "cursor-not-allowed" : "cursor-pointer"}`} {...rest}>
       {({ checked }) => (
-        <div className={`flex items-center ${classNameWrapper ?? ""}`}>
+        <div className={`flex items-baseline ${classNameWrapper ?? ""}`}>
           <span
             className={`${classNameCheckbox ?? ""} ${
               checked ? "bg-primary-10 ring-2 ring-primary-9 border-neutral-0 border-4" : "border-2 border-neutral-5"
-            } inline-flex mie-2 w-4 h-4 rounded-full border-solid`}
+            } translate-y-0.5 inline-flex mie-2 w-4 h-4 rounded-full border-solid`}
           />
           <span
             className={`flex-wrap items-center pie-3 flex w-full  text-true-white ${

--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/Form.tsx
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/Form.tsx
@@ -13,7 +13,7 @@ import FormRadioOption from "@components/FormRadioOption";
 import FormRadioGroup from "@components/FormRadioGroup";
 import ToggleSwitch from "@components/ToggleSwitch";
 import { useId } from "react";
-import { InformationCircleIcon, ShieldExclamationIcon } from "@heroicons/react/outline";
+import { ShieldExclamationIcon } from "@heroicons/react/outline";
 interface FormProps {
   isDeploying: boolean;
   // the following are returned by felte hook useForm()
@@ -304,7 +304,7 @@ export const Form = (props: FormProps) => {
                         ? "true"
                         : "false"
                     }
-                    value={data()?.useSameTokenForSubmissions ? dataDeploySubmissionToken?.address : data()?.submissionTokenAddress}
+                    value={data()?.useSameTokenForSubmissions ? "" : data()?.submissionTokenAddress}
                     required={data()?.useSameTokenForSubmissions === true}
                     className="w-full"
                     placeholder="0x..."


### PR DESCRIPTION
# Description
> The submission token value is pre-filled with the previously minted voting token address, which is confusing.
![image_2022-09-08_09-34-37](https://user-images.githubusercontent.com/15010369/189141132-a18ec319-0607-4bb2-8c87-df87e8d76f9e.png)

- This PR changes this behaviour and Keep the submission token address value empty if the user picks "Use the same token for both submitting proposals and voting" to avoid confusion

- Align radio inputs on the baseline

## Type of change
- [x] Bugfix (no breaking changes) 
