### PR TITLE
bugfix#56:  Display "your remaining votes" after a contest instead of "Your used votes"

### DIFF
--- a/packages/react-app-revamp/layouts/LayoutViewContest/VotingToken/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/VotingToken/index.tsx
@@ -22,11 +22,10 @@ export const VotingToken = () => {
     <>
       <div className="font-black leading-snug flex flex-wrap space-i-1ex md:space-i-0 md:flex-col items-center slashed-zero tabular-nums">
         <span className="text-sm font-bold pb-0.5">
-          {isBefore(new Date(), votesOpen)
+          {isBefore(new Date(), votesClose)
             ? "Your available votes"
-            : isAfter(new Date(), votesClose)
-            ? "Your used votes:"
-            : "Your remaining votes:"}
+            : "Your remaining votes:"
+          }
         </span>
         {isBefore(new Date(), votesOpen) ? (
           <>


### PR DESCRIPTION
# Description
- Typo:   Display "your remaining votes" after a contest instead of "Your used votes"

Fixes #56 

## Screenshots
![Screenshot_20220908_151914](https://user-images.githubusercontent.com/15010369/189144560-f9034a7b-a3fe-42dd-9ed7-3744c4dbb7c5.png)

![Screenshot_20220908_152918](https://user-images.githubusercontent.com/15010369/189144580-dc1a7a73-0724-4ef2-8963-59cc720a1025.png)


![Screenshot_20220908_153825](https://user-images.githubusercontent.com/15010369/189144481-cc8de9c3-115d-4ed6-a79e-9390242e3fa4.png)


## Type of change
- [x] Bugfix (no breaking changes) 
