### PR TITLE
bugfix: display 'no submission token' 

### DIFF
--- a/packages/react-app-revamp/pages/contest/[chain]/[address]/rules/index.tsx
+++ b/packages/react-app-revamp/pages/contest/[chain]/[address]/rules/index.tsx
@@ -79,11 +79,13 @@ const Page: NextPage = (props: PageProps) => {
      </section>
      <section>
       <h2 className='uppercase font-bold mb-2'>Submission token</h2>
-      <ul className='list-disc pis-4 leading-loose'>
+      {submitProposalToken?.address !== votingToken?.address ? <ul className='list-disc pis-4 leading-loose'>
         <li title={`$${submitProposalToken.symbol}`} className='list-item'><span className='block whitespace-nowrap overflow-hidden text-ellipsis'>Symbol: <span className='font-bold normal-case'>${submitProposalToken.symbol}</span></span></li>
         <li title={`${new Intl.NumberFormat().format(submitProposalToken.totalSupply.formatted)}`} className='list-item'><span className='block whitespace-nowrap overflow-hidden text-ellipsis'>Total supply: <span className='font-bold'>{new Intl.NumberFormat().format(submitProposalToken.totalSupply.formatted)}</span></span></li>
         <li title={submitProposalToken.address} className='list-item'><span className='block whitespace-nowrap overflow-hidden text-ellipsis'>Contract: <a className='link' target="_blank" rel="noreferrer nofollow" href={`${chains.filter(chain => chain.name.replace(' ', '').toLowerCase() === asPath.split("/")[2])[0].blockExplorers?.default.url}/address/${submitProposalToken.address}`.replace('//address', '/address')}>{submitProposalToken.address}</a></span></li>
-      </ul>
+      </ul> : <p className='italic text-neutral-11'>
+        No submission token for this contest
+      </p>}
      </section>
      <section>
       <h2 className='uppercase font-bold mb-2'>Voting token</h2>


### PR DESCRIPTION
# Description
* Display 'No submission token for this contest' instead of voting token info when a contest has no submission token

Should fix #82 

## Screenshots
![Screenshot 2022-09-13 at 15-31-08 JokeDAO 🃏 An open-source collaborative decision-making platform](https://user-images.githubusercontent.com/15010369/189914625-f8049938-a630-44c2-853f-0b9b2e17a85a.png)


