### PR TITLE
Bugfix: Rules page displays an error when user wallet isn't connected

### DIFF
--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/Form.tsx
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/Form.tsx
@@ -344,7 +344,7 @@ export const Form = (props: FormProps) => {
             </FormRadioOption>
           </FormRadioGroup>
           <div className={`${data()?.whoCanSubmit !== "mustHaveSubmissionTokens" ? "pointer-events-none opacity-75" : ""} pis-6 text-sm !mt-0.5 flex items-center flex-wrap`}>
-                <span className="pie-1ex">Address of the submission token</span>
+                <span className="pie-1ex">Address of the submission token:</span>
                 <div className="flex-grow py-1">
                   <FormInput
                     disabled={

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -294,12 +294,12 @@ export function useContest() {
         setSubmitProposalTokenAddress(results[4]);
         setSubmitProposalToken(votingTokenRawData);
       }
+      // Check snapshot
       await checkIfCurrentUserQualifyToVote();
 
       if(accountData?.address) {
         // Current user votes
         await updateCurrentUserVotes();
-        // Check snapshot
       }
       // If current page is proposal, fetch proposal with id
       if(asPath.includes('/proposal/')) {

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -294,11 +294,12 @@ export function useContest() {
         setSubmitProposalTokenAddress(results[4]);
         setSubmitProposalToken(votingTokenRawData);
       }
+      await checkIfCurrentUserQualifyToVote();
+
       if(accountData?.address) {
         // Current user votes
         await updateCurrentUserVotes();
         // Check snapshot
-        await checkIfCurrentUserQualifyToVote();
       }
       // If current page is proposal, fetch proposal with id
       if(asPath.includes('/proposal/')) {
@@ -451,15 +452,19 @@ export function useContest() {
         const timestampToCheck =
           //@ts-ignore
           delayedCurrentTimestamp >= timestampSnapshotRawData ? timestampSnapshotRawData : delayedCurrentTimestamp;
+          if(accountData?.address) {
+            const tokenUserWasHoldingAtSnapshotRawData = await readContract({
+              ...contractConfig,
+              functionName: "getVotes",
+              //@ts-ignore
+              args: [accountData?.address, timestampToCheck],
+            });
+            //@ts-ignore
+            setDidUserPassSnapshotAndCanVote(tokenUserWasHoldingAtSnapshotRawData / 1e18 > 0);    
+          } else {
+            setDidUserPassSnapshotAndCanVote(false)
+          }
 
-        const tokenUserWasHoldingAtSnapshotRawData = await readContract({
-          ...contractConfig,
-          functionName: "getVotes",
-          //@ts-ignore
-          args: [accountData?.address, timestampToCheck],
-        });
-        //@ts-ignore
-        setDidUserPassSnapshotAndCanVote(tokenUserWasHoldingAtSnapshotRawData / 1e18 > 0);
       } else {
         setSnapshotTaken(false);
       }

--- a/packages/react-app-revamp/pages/contest/[chain]/[address]/rules/index.tsx
+++ b/packages/react-app-revamp/pages/contest/[chain]/[address]/rules/index.tsx
@@ -8,6 +8,7 @@ import Steps from '@layouts/LayoutViewContest/Timeline/Steps'
 import { format } from 'date-fns'
 import { CONTEST_STATUS } from '@helpers/contestStatus'
 import { useRouter } from 'next/router'
+import { useAccount } from 'wagmi'
 
 interface PageProps {
   address: string,
@@ -16,6 +17,7 @@ interface PageProps {
 const Page: NextPage = (props: PageProps) => {
   const { address } = props
   const { asPath } = useRouter()
+  const accountData = useAccount()
   const { contestState, checkIfUserPassedSnapshotLoading, snapshotTaken, didUserPassSnapshotAndCanVote, usersQualifyToVoteIfTheyHoldTokenAtTime, votingToken, contestMaxNumberSubmissionsPerUser,  amountOfTokensRequiredToSubmitEntry, contestMaxProposalCount, isSuccess, isLoading, contestName, submitProposalToken } = useStore(state =>  ({ 
     //@ts-ignore
     votingToken: state.votingToken,
@@ -55,9 +57,9 @@ const Page: NextPage = (props: PageProps) => {
     {!isLoading  && isSuccess && <div className='animate-appear space-y-8'>
      {contestState !== CONTEST_STATUS.SNAPSHOT_ONGOING && <section className='animate-appear'>
        <p className={`p-3 mt-4 rounded-md border-solid border mb-5 text-sm font-bold
-       ${(!snapshotTaken || checkIfUserPassedSnapshotLoading ) ? ' border-neutral-4' : didUserPassSnapshotAndCanVote ? 'bg-positive-1 text-positive-10 border-positive-4' : ' bg-primary-1 text-primary-10 border-primary-4'}`
+       ${(!snapshotTaken || checkIfUserPassedSnapshotLoading || !accountData?.address) ? ' border-neutral-4' : didUserPassSnapshotAndCanVote ? 'bg-positive-1 text-positive-10 border-positive-4' : ' bg-primary-1 text-primary-10 border-primary-4'}`
        }>
-         {checkIfUserPassedSnapshotLoading ? 'Checking snapshot...' : !snapshotTaken ? 'Snapshot hasn\'t been taken yet.': didUserPassSnapshotAndCanVote ? 'Congrats ! Your wallet qualified to vote.' : 'Too bad, your wallet didn\'t qualify to vote.'}
+         {!accountData?.address ? "Connect your wallet to see if you qualified to vote." : checkIfUserPassedSnapshotLoading ? 'Checking snapshot...' : !snapshotTaken ? 'Snapshot hasn\'t been taken yet.': didUserPassSnapshotAndCanVote ? 'Congrats ! Your wallet qualified to vote.' : 'Too bad, your wallet didn\'t qualify to vote.'}
        </p>
      </section>}
      <section>


### PR DESCRIPTION
# Description
> In contest rules page, this error pops when a wallet isn't connected
![photo_2022-09-13_22-37-52](https://user-images.githubusercontent.com/15010369/190094456-ae8cf61e-9fb2-476e-8716-93acfe53bf80.jpg)

* Bugfix: fix rules page displays an error when user wallet isn't connected

This error was due to `checkIfCurrentUserQualifyToVote()` not being called anymore when the user wallet isn't connected. This function calls `contestSnapshot` which returned value is used to set `usersQualifyToVoteIfTheyHoldTokenAtTime`, a variable used in the rules page.

`checkIfCurrentUserQualifyToVote()` is now called even when the current user didn't connect their wallet, and we now prevent `getVotes` from being called if the current user isn't connected (calling it would cause an error).

* Bugfix: display a different message in the callout in rules page if the user wallet isn't connected

![Screenshot 2022-09-14 at 09-57-00 JokeDAO 🃏 An open-source collaborative decision-making platform](https://user-images.githubusercontent.com/15010369/190095691-8924ab61-838c-469b-a864-eb5f5f46290e.png)


* Typo: add a colon in the contest rules form after the label `Address of the submission token`
![Screenshot 2022-09-14 at 09-44-51 JokeDAO 🃏 An open-source collaborative decision-making platform](https://user-images.githubusercontent.com/15010369/190092937-e5eee9ec-7271-47ec-9399-e52bfbe3c0cc.png)
![Screenshot_20220914_094524](https://user-images.githubusercontent.com/15010369/190093042-c423f5a0-6d11-42a1-8dee-05c1b39fd243.png)




