### PR TITLE
bugfix: change button styles in wizard form steps

### DIFF
--- a/packages/react-app-revamp/components/Button/styles.ts
+++ b/packages/react-app-revamp/components/Button/styles.ts
@@ -37,6 +37,12 @@ export const button = cva(
           'text-true-white hover:text-neutral-1 focus:text-true-black',
           'border-primary-9 hover:border-primary-10 hover:focus:border-primary-10 focus:border-primary-11',
         ],
+        'ghost-neutral': [
+          'bg-true-white bg-opacity-0 hover:bg-opacity-5 focus:bg-opacity-100',
+          'text-true-white focus:text-true-black',
+          'border-transparent',
+          'focus:outline-none'
+        ]
       },
       scale: {
         default: ['text-xs', 'py-2 px-4 sm:px-5', 'font-bold', 'border'],

--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step1/index.tsx
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step1/index.tsx
@@ -25,7 +25,7 @@ export const Step1 = () => {
           To create one, we’ll <span>mint a voting token, set the rules, and then airdrop the token</span> to your
           community.
         </p>
-        <p className="font-bold !mb-6">Sound good ?</p>
+        <p className="font-bold !mb-8 !md:mb-12">Sound good ?</p>
         <Button className="w-full 2xs:w-auto" intent="neutral-outline" onClick={() => setCurrentStep(2)}>
           Let’s do it 🔥
         </Button>

--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step1/index.tsx
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step1/index.tsx
@@ -25,7 +25,7 @@ export const Step1 = () => {
           To create one, we’ll <span>mint a voting token, set the rules, and then airdrop the token</span> to your
           community.
         </p>
-        <p className="font-bold">Sound good ?</p>
+        <p className="font-bold !mb-6">Sound good ?</p>
         <Button className="w-full 2xs:w-auto" intent="neutral-outline" onClick={() => setCurrentStep(2)}>
           Let’s do it 🔥
         </Button>

--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step2/Form.tsx
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step2/Form.tsx
@@ -193,7 +193,7 @@ export const Form = (props: FormProps) => {
           />
         </FormField>
       </fieldset>
-      <div className="pt-6 flex flex-col space-y-5">
+      <div className="pt-8 md:pt-12 flex flex-col space-y-5">
         <Button
           className="sm:w-fit-content"
           isLoading={isDeploying === true}

--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step2/Form.tsx
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step2/Form.tsx
@@ -23,7 +23,7 @@ interface FormProps {
   setData: any;
   setFields: any;
 }
-const appearAsNeutralButton = button({ intent: "ghost-neutral" });
+const appearAsNeutralButton = button({ intent: "ghost-neutral", scale: "sm", class: "min-w-[12ex]" });
 
 export const Form = (props: FormProps) => {
   const formId = useId();

--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step2/Form.tsx
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step2/Form.tsx
@@ -23,7 +23,7 @@ interface FormProps {
   setData: any;
   setFields: any;
 }
-const appearAsNeutralButton = button({ intent: "ghost-neutral", scale: "sm", class: "min-w-[12ex]" });
+const appearAsNeutralButton = button({ intent: "ghost-neutral", scale: "sm", class: "sm:w-fit-content" });
 
 export const Form = (props: FormProps) => {
   const formId = useId();
@@ -193,8 +193,9 @@ export const Form = (props: FormProps) => {
           />
         </FormField>
       </fieldset>
-      <div className="pt-6 flex flex-col xs:flex-row space-y-3 xs:space-y-0 xs:space-i-3">
+      <div className="pt-6 flex flex-col space-y-5">
         <Button
+          className="sm:w-fit-content"
           isLoading={isDeploying === true}
           //@ts-ignore
           disabled={

--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step2/Form.tsx
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step2/Form.tsx
@@ -23,7 +23,7 @@ interface FormProps {
   setData: any;
   setFields: any;
 }
-const appearAsNeutralButton = button({ intent: "neutral-outline" });
+const appearAsNeutralButton = button({ intent: "ghost-neutral" });
 
 export const Form = (props: FormProps) => {
   const formId = useId();
@@ -197,7 +197,6 @@ export const Form = (props: FormProps) => {
         <Button
           isLoading={isDeploying === true}
           //@ts-ignore
-          intent="neutral-oultine"
           disabled={
             !account.isConnected ||
             chain?.unsupported === true ||

--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/Form.tsx
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/Form.tsx
@@ -735,7 +735,7 @@ export const Form = (props: FormProps) => {
           Create contest
         </Button>
 
-        <div className={button({ intent: "ghost-neutral" })} tabIndex={0} role="button" {...pressProps}>
+        <div className={button({ intent: "ghost-neutral", scale: "sm", class: "min-w-[12ex]" })} tabIndex={0} role="button" {...pressProps}>
           Next
         </div>
       </div>

--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/Form.tsx
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/Form.tsx
@@ -712,8 +712,9 @@ export const Form = (props: FormProps) => {
           </FormField>
         </div>
       </fieldset>
-      <div className="pt-6 flex flex-col xs:flex-row space-y-3 xs:space-y-0 xs:space-i-3">
+      <div className="pt-6 flex flex-col space-y-5">
         <Button
+          className="sm:w-fit-content"
           isLoading={isDeploying === true}
           //@ts-ignore
           disabled={
@@ -735,7 +736,7 @@ export const Form = (props: FormProps) => {
           Create contest
         </Button>
 
-        <div className={button({ intent: "ghost-neutral", scale: "sm", class: "min-w-[12ex]" })} tabIndex={0} role="button" {...pressProps}>
+        <div className={button({ intent: "ghost-neutral", scale: "sm", class: "sm:w-fit-content" })} tabIndex={0} role="button" {...pressProps}>
           Next
         </div>
       </div>

--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/Form.tsx
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/Form.tsx
@@ -716,7 +716,6 @@ export const Form = (props: FormProps) => {
         <Button
           isLoading={isDeploying === true}
           //@ts-ignore
-          intent="neutral-oultine"
           disabled={
             !isValid() ||
             interacted() === null ||
@@ -736,7 +735,7 @@ export const Form = (props: FormProps) => {
           Create contest
         </Button>
 
-        <div className={button({ intent: "neutral-outline" })} tabIndex={0} role="button" {...pressProps}>
+        <div className={button({ intent: "ghost-neutral" })} tabIndex={0} role="button" {...pressProps}>
           Next
         </div>
       </div>

--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/Form.tsx
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/Form.tsx
@@ -712,7 +712,7 @@ export const Form = (props: FormProps) => {
           </FormField>
         </div>
       </fieldset>
-      <div className="pt-6 flex flex-col space-y-5">
+      <div className="pt-8 md:pt-12 flex flex-col space-y-5">
         <Button
           className="sm:w-fit-content"
           isLoading={isDeploying === true}

--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step4/TextInstructions.tsx
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step4/TextInstructions.tsx
@@ -69,22 +69,23 @@ export const TextInstructions = () => {
                     </span>
                   </>
                 )}
-              <br /> You can always find it on{" "}
-              <Link
-                href={{
-                  pathname: ROUTE_VIEW_CONTEST,
-                  //@ts-ignore
-                  query: {
-                    chain: contestDeployedToChain.name.toLowerCase().replace(" ", ""),
-                    address: dataDeployContest?.address,
-                  },
-                }}
-              >
-                <a target="_blank" className="link">
-                  the contest page
-                </a>
-              </Link>
-              .
+              {dataDeployContest?.address && <>
+                <br /> You can always find it on{" "}
+                <Link
+                  href={{
+                    pathname: ROUTE_VIEW_CONTEST,
+                    //@ts-ignore
+                    query: {
+                      chain: contestDeployedToChain.name.toLowerCase().replace(" ", ""),
+                      address: dataDeployContest?.address,
+                    },
+                  }}
+                >
+                  <a target="_blank" className="link">
+                    the contest page
+                  </a>
+                </Link>.
+              </>}
             </p>
           </>
         )}


### PR DESCRIPTION
# Description
>  Button should say "next" instead of "skip" ; In addition, the "create contest" button should be in bright yellow to encourage users to tap it rather than pressing "skip" And "skip" should be in plain text in a smaller font below "create contest" so that it's not prioritized

- feat: create new button intent ("ghost-neutral")
- bugfix: change step 2 and step 3 skip/next button scale to "sm" and change their intent to "ghost-neutral"
- bugfix: change step 2 and step 3 CTA button from "neutral-outline" to "primary"
- bugfix: fix airdrop step (step 4) bug when user didn't create a contest first

Closes #60 

## Screenshots
![Screenshot 2022-09-16 at 11-47-56 JokeDAO 🃏 An open-source collaborative decision-making platform](https://user-images.githubusercontent.com/15010369/190611428-17d17245-8212-4e1c-919e-3e6123221067.png)


## Type of change
- [x] Bugfix