### PR TITLE
bugfix: export contest as csv fails after loading 13 proposals

### DIFF
--- a/packages/react-app-revamp/components/_pages/ButtonDownloadContestDataAsCSV/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ButtonDownloadContestDataAsCSV/index.tsx
@@ -31,33 +31,47 @@ export const ButtonDownloadContestDataAsCSV = () => {
   );
 
   const { stateExportData, formatContestCSVData } = useExportContestDataToCSV();
-  useEffect(() => {
-    const startDownloading = async () => {
-      stateExportData.setLoadingMessage("Loading remaining proposals data...");
-      stateExportData.setIsReady(false);
-      try {
-        if (hasPaginationProposalsNextPage) {
-          const loadAllContestData = [];
-          for (let i = currentPagePaginationProposals; i < totalPagesPaginationProposals - 1; i++) {
-            loadAllContestData.push(
-              fetchProposalsPage(i + 1, indexPaginationProposals[i + 1], totalPagesPaginationProposals),
-            );
-          }
-          await Promise.all(loadAllContestData);
+  async function startDownloading() {
+    stateExportData.setLoadingMessage("Loading remaining proposals data...");
+    stateExportData.setIsReady(false);
+    try {
+      if (hasPaginationProposalsNextPage) {
+        const loadAllContestData = [];
+        for (let i = currentPagePaginationProposals; i < totalPagesPaginationProposals - 1; i++) {
+          loadAllContestData.push(
+            fetchProposalsPage(i + 1, indexPaginationProposals[i + 1], totalPagesPaginationProposals),
+          );
         }
-        stateExportData.setIsReady(true);
-      } catch (e) {
-        stateExportData.setIsReady(false);
-        console.error(e);
+        await Promise.all(loadAllContestData);
       }
-    };
-    startDownloading();
-  }, []);
+      stateExportData.setIsReady(true);
+    } catch (e) {
+      stateExportData.setIsReady(false);
+      console.error(e);
+    }
+  }
+
+  useEffect(() => {
+    if (stateExportData.shouldStart === true) startDownloading();
+  }, [stateExportData.shouldStart]);
 
   useEffect(() => {
     if (stateExportData.isReady === true) formatContestCSVData();
   }, [stateExportData.isReady]);
 
+  if (!stateExportData.shouldStart)
+    return (
+      <>
+        <Button
+          className="animate-appear"
+          intent="neutral-outline"
+          onClick={() => stateExportData.setShouldStart(true)}
+          type="button"
+        >
+          Start exporting data
+        </Button>
+      </>
+    );
   return (
     <>
       {(stateExportData.isLoading || !stateExportData.isReady) && (
@@ -87,11 +101,11 @@ export const ButtonDownloadContestDataAsCSV = () => {
           {/* @ts-ignore */}
           <CSVLink
             filename={`jokedao-contest-data-${format(new Date(), "yyyy-MM-dd")}.csv`}
-            className={button({ intent: "neutral-outline" })}
+            className={button({ intent: "primary-outline" })}
             data={stateExportData.csv}
             headers={CSV_COLUMNS_HEADERS}
           >
-            Export
+            Download CSV file
           </CSVLink>
         </div>
       )}

--- a/packages/react-app-revamp/components/_pages/ButtonDownloadContestDataAsCSV/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ButtonDownloadContestDataAsCSV/index.tsx
@@ -1,29 +1,66 @@
 import { useEffect } from "react";
-import { useNetwork } from "wagmi";
+import shallow from "zustand/shallow";
 import { useExportContestDataToCSV } from "@hooks/useExportContestDataToCSV/useExportContestDataToCSV";
-import { useRouter } from "next/router";
+import { useStore as useStoreContest } from "@hooks/useContest/store";
 import useContest from "@hooks/useContest";
 import { CSV_COLUMNS_HEADERS } from "@config/react-csv/export-contest";
 import { CSVLink } from "react-csv";
 import button from "@components/Button/styles";
 import Button from "@components/Button";
 import Loader from "@components/Loader";
+import { format } from "date-fns";
 export const ButtonDownloadContestDataAsCSV = () => {
-  const { chain } = useNetwork();
-  const { asPath } = useRouter();
-  const { chainId } = useContest();
+  const { fetchProposalsPage } = useContest();
+  const {
+    hasPaginationProposalsNextPage,
+    indexPaginationProposals,
+    totalPagesPaginationProposals,
+    currentPagePaginationProposals,
+  } = useStoreContest(
+    state => ({
+      //@ts-ignore
+      totalPagesPaginationProposals: state.totalPagesPaginationProposals,
+      //@ts-ignore
+      currentPagePaginationProposals: state.currentPagePaginationProposals,
+      //@ts-ignore
+      indexPaginationProposals: state.indexPaginationProposals,
+      //@ts-ignore
+      hasPaginationProposalsNextPage: state.hasPaginationProposalsNextPage,
+    }),
+    shallow,
+  );
+
   const { stateExportData, formatContestCSVData } = useExportContestDataToCSV();
   useEffect(() => {
     const startDownloading = async () => {
-      await formatContestCSVData();
+      stateExportData.setLoadingMessage("Loading remaining proposals data...");
+      stateExportData.setIsReady(false);
+      try {
+        if (hasPaginationProposalsNextPage) {
+          const loadAllContestData = [];
+          for (let i = currentPagePaginationProposals; i < totalPagesPaginationProposals - 1; i++) {
+            loadAllContestData.push(
+              fetchProposalsPage(i + 1, indexPaginationProposals[i + 1], totalPagesPaginationProposals),
+            );
+          }
+          await Promise.all(loadAllContestData);
+        }
+        stateExportData.setIsReady(true);
+      } catch (e) {
+        stateExportData.setIsReady(false);
+        console.error(e);
+      }
     };
-    if (chain?.id === chainId) {
-      startDownloading();
-    }
-  }, [chain?.id, chainId, asPath.split("/")[2], asPath.split("/")[3]]);
+    startDownloading();
+  }, []);
+
+  useEffect(() => {
+    if (stateExportData.isReady === true) formatContestCSVData();
+  }, [stateExportData.isReady]);
+
   return (
     <>
-      {stateExportData.isLoading && (
+      {(stateExportData.isLoading || !stateExportData.isReady) && (
         <div className="animate-appear mb-5">
           <Loader scale="component">{stateExportData.loadingMessage}</Loader>
         </div>
@@ -49,6 +86,7 @@ export const ButtonDownloadContestDataAsCSV = () => {
         <div className="mt-6 animate-appear">
           {/* @ts-ignore */}
           <CSVLink
+            filename={`jokedao-contest-data-${format(new Date(), "yyyy-MM-dd")}.csv`}
             className={button({ intent: "neutral-outline" })}
             data={stateExportData.csv}
             headers={CSV_COLUMNS_HEADERS}

--- a/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
@@ -289,7 +289,7 @@ export const ListProposals = () => {
               Loading proposals...
             </Loader>
           )}
-          {Object.keys(listProposalsData)?.length < listProposalsIds && !isPageProposalsLoading && (
+          {Object.keys(listProposalsData)?.length < listProposalsIds.length && !isPageProposalsLoading && (
             <div className="pt-8 flex animate-appear">
               <Button
                 intent="neutral-outline"

--- a/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
@@ -13,7 +13,7 @@ import styles from "./styles.module.css";
 import { IconCaretDown, IconCaretUp, IconSpinner } from "@components/Icons";
 import { CONTEST_STATUS } from "@helpers/contestStatus";
 import { useAccount } from "wagmi";
-import { useContest } from "@hooks/useContest" 
+import { useContest } from "@hooks/useContest";
 import isProposalDeleted from "@helpers/isProposalDeleted";
 import Loader from "@components/Loader";
 
@@ -33,7 +33,6 @@ export const ListProposals = () => {
     downvotingAllowed,
     listProposalsIds,
     currentUserSubmitProposalTokensAmount,
-    hasPaginationProposalsNextPage,
     isPageProposalsLoading,
     isPageProposalsError,
     currentPagePaginationProposals,
@@ -43,8 +42,6 @@ export const ListProposals = () => {
     state => ({
       //@ts-ignore
       currentPagePaginationProposals: state.currentPagePaginationProposals,
-      //@ts-ignore
-      hasPaginationProposalsNextPage: state.hasPaginationProposalsNextPage,
       //@ts-ignore
       isPageProposalsLoading: state.isPageProposalsLoading,
       //@ts-ignore
@@ -103,8 +100,7 @@ export const ListProposals = () => {
     shallow,
   );
 
-  const { fetchProposalsPage } = useContest()
-
+  const { fetchProposalsPage } = useContest();
   function onClickUpVote(proposalId: number | string) {
     setCastPositiveAmountOfVotes(true);
     setPickedProposalToVoteFor(proposalId);
@@ -150,167 +146,168 @@ export const ListProposals = () => {
         </div>
       );
     } else {
-
-      if(isPageProposalsLoading && Object.keys(listProposalsData)?.length === 0) {
-        return <Loader scale="component">
-          Loading proposals...
-        </Loader>
+      if (isPageProposalsLoading && Object.keys(listProposalsData)?.length === 0) {
+        return <Loader scale="component">Loading proposals...</Loader>;
       }
       return (
         <>
-        <ul className={`${styles.list} space-y-12`}>
-          {Object.keys(listProposalsData)
-            .sort((a, b) => {
-
-              if (listProposalsData[a].votes > listProposalsData[b].votes) {
-                return -1;
-              }
-              if (listProposalsData[a].votes < listProposalsData[b].votes) {
-                return 1;
-              }
-              return 0;
-            })
-            .map((id, i) => {
-              return (
-                <li
-                  className={`${styles.listElement} animate-appear px-5 pt-5 pb-3 rounded-md 2xs:rounded-none 2xs:p-0 border border-solid border-neutral-1 2xs:border-0 relative overflow-hidden text-sm ${styles.wrapper}`}
-                  key={id}
-                >
-                  <div className="text-center 2xs:border-is-4 border-solid border-neutral-1 2xs:border-neutral-5 flex flex-col 2xs:items-center pt-2 2xs:pt-0">
-                    {contestStatus === CONTEST_STATUS.SUBMISSIONS_OPEN ? (
-                      <span className="text-3xs text-neutral-11 italic">Vote not open yet</span>
-                    ) : (
-                      <>
-                        {listProposalsData[id].votes > 0 && (
-                          <span
-                            className={`${styles.rankIndicator} hidden 2xs:flex rounded-full items-center justify-center aspect-square text-opacity-100 mb-3`}
-                          >
-                            #{i + 1}
-                          </span>
-                        )}
-                        <div className=" text-neutral-12 flex space-y-2 flex-col items-center justify-center font-bold text-2xs">
-                          {(contestStatus === CONTEST_STATUS.VOTING_OPEN && checkIfUserPassedSnapshotLoading) ||
-                            (contestStatus === CONTEST_STATUS.SNAPSHOT_ONGOING && (
-                              <IconSpinner className="text-sm animate-spin mie-2 2xs:mie-0 2xs:mb-1" />
-                            ))}
-                          {!isProposalDeleted(listProposalsData[id].content) &&
-                            didUserPassSnapshotAndCanVote &&
-                            contestStatus === CONTEST_STATUS.VOTING_OPEN &&
-                            currentUserAvailableVotesAmount > 0 && (
-                              <button
-                                onClick={() => onClickUpVote(id)}
-                                disabled={
-                                  checkIfUserPassedSnapshotLoading ||
-                                  !didUserPassSnapshotAndCanVote ||
-                                  contestStatus !== CONTEST_STATUS.VOTING_OPEN ||
-                                  currentUserAvailableVotesAmount === 0
-                                }
-                                className="w-full 2xs:w-auto disabled:text-opacity-50 disabled:cursor-not-allowed disabled:border-none border border-solid border-neutral-5 rounded-md p-2 2xs:p-1.5 flex items-center justify-center"
-                              >
-                                <IconCaretUp className="text-2xs mie-2 2xs:mie-0" />
-                                <span className="2xs:sr-only">Up vote</span>
-                              </button>
-                            )}
-                          <span className="flex 2xs:flex-col">
-                            {Intl.NumberFormat("en-US", {
-                              notation: "compact",
-                              maximumFractionDigits: 3,
-                            }).format(parseFloat(listProposalsData[id].votes))}{" "}
-                            <span className="text-neutral-11 pis-1ex 2xs:pis-0 text-3xs">
-                              vote
-                              {(listProposalsData[id].votes > 1 ||
-                                listProposalsData[id].votes < -1 ||
-                                listProposalsData[id].votes === 0) &&
-                                "s"}
+          <ul className={`${styles.list} space-y-12`}>
+            {Object.keys(listProposalsData)
+              .sort((a, b) => {
+                if (listProposalsData[a].votes > listProposalsData[b].votes) {
+                  return -1;
+                }
+                if (listProposalsData[a].votes < listProposalsData[b].votes) {
+                  return 1;
+                }
+                return 0;
+              })
+              .map((id, i) => {
+                return (
+                  <li
+                    className={`${styles.listElement} animate-appear px-5 pt-5 pb-3 rounded-md 2xs:rounded-none 2xs:p-0 border border-solid border-neutral-1 2xs:border-0 relative overflow-hidden text-sm ${styles.wrapper}`}
+                    key={id}
+                  >
+                    <div className="text-center 2xs:border-is-4 border-solid border-neutral-1 2xs:border-neutral-5 flex flex-col 2xs:items-center pt-2 2xs:pt-0">
+                      {contestStatus === CONTEST_STATUS.SUBMISSIONS_OPEN ? (
+                        <span className="text-3xs text-neutral-11 italic">Vote not open yet</span>
+                      ) : (
+                        <>
+                          {listProposalsData[id].votes > 0 && (
+                            <span
+                              className={`${styles.rankIndicator} hidden 2xs:flex rounded-full items-center justify-center aspect-square text-opacity-100 mb-3`}
+                            >
+                              #{i + 1}
                             </span>
-                          </span>
-                          {!isProposalDeleted(listProposalsData[id].content) &&
-                            didUserPassSnapshotAndCanVote &&
-                            contestStatus === CONTEST_STATUS.VOTING_OPEN &&
-                            currentUserAvailableVotesAmount > 0 &&
-                            downvotingAllowed === true && (
-                              <button
-                                onClick={() => onClickDownVote(id)}
-                                disabled={
-                                  checkIfUserPassedSnapshotLoading ||
-                                  !didUserPassSnapshotAndCanVote ||
-                                  contestStatus !== CONTEST_STATUS.VOTING_OPEN ||
-                                  currentUserAvailableVotesAmount === 0
-                                }
-                                className="w-full 2xs:w-auto disabled:text-opacity-50 disabled:cursor-not-allowed disabled:border-none border border-solid border-neutral-5 rounded-md p-2 2xs:p-1.5 flex items-center justify-center"
-                              >
-                                <IconCaretDown className="text-2xs mie-2 2xs:mie-0" />
-                                <span className="2xs:sr-only">Down vote</span>
-                              </button>
-                            )}
-                        </div>
-                      </>
-                    )}
-                  </div>
-                  <div className="relative overflow-hidden">
-                    {listProposalsData[id].votes > 0 && (
-                      <span
-                        className={`${styles.rankIndicator} inline-flex 2xs:hidden rounded-full items-center justify-center aspect-square text-opacity-100 mb-3`}
-                      >
-                        #{i + 1}
-                      </span>
-                    )}
-                    <ProposalContent
-                      author={listProposalsData[id].author}
-                      content={
-                        listProposalsData[id].isContentImage
-                          ? listProposalsData[id].content
-                          : truncate(listProposalsData[id].content, 280)
-                      }
-                    />
-                    <Link
-                      href={{
-                        pathname: ROUTE_CONTEST_PROPOSAL,
-                        //@ts-ignore
-                        query: {
-                          chain,
-                          address,
-                          proposal: id,
-                        },
-                      }}
-                    >
-                      <a title={`View proposal #${id}`} className="absolute opacity-0 inset-0 w-full h-full z-10 ">
-                        View proposal #{id}
-                      </a>
-                    </Link>
-                    {!isProposalDeleted(listProposalsData[id].content) &&
-                      contestAuthorEthereumAddress === accountData?.address && (
-                        <button
-                          onClick={() => onClickProposalDelete(id)}
-                          className="w-full 2xs:w-auto mt-6 text-xs 2xs:text-2xs rounded-md py-1.5 2xs:py-1 px-3 relative z-20 bg-negative-4 hover:bg-opacity-50 focus:bg-opacity-75 text-negative-11 bg-opacity-40"
-                        >
-                          <span className="font-bold">Delete this proposal</span>
-                        </button>
+                          )}
+                          <div className=" text-neutral-12 flex space-y-2 flex-col items-center justify-center font-bold text-2xs">
+                            {(contestStatus === CONTEST_STATUS.VOTING_OPEN && checkIfUserPassedSnapshotLoading) ||
+                              (contestStatus === CONTEST_STATUS.SNAPSHOT_ONGOING && (
+                                <IconSpinner className="text-sm animate-spin mie-2 2xs:mie-0 2xs:mb-1" />
+                              ))}
+                            {!isProposalDeleted(listProposalsData[id].content) &&
+                              didUserPassSnapshotAndCanVote &&
+                              contestStatus === CONTEST_STATUS.VOTING_OPEN &&
+                              currentUserAvailableVotesAmount > 0 && (
+                                <button
+                                  onClick={() => onClickUpVote(id)}
+                                  disabled={
+                                    checkIfUserPassedSnapshotLoading ||
+                                    !didUserPassSnapshotAndCanVote ||
+                                    contestStatus !== CONTEST_STATUS.VOTING_OPEN ||
+                                    currentUserAvailableVotesAmount === 0
+                                  }
+                                  className="w-full 2xs:w-auto disabled:text-opacity-50 disabled:cursor-not-allowed disabled:border-none border border-solid border-neutral-5 rounded-md p-2 2xs:p-1.5 flex items-center justify-center"
+                                >
+                                  <IconCaretUp className="text-2xs mie-2 2xs:mie-0" />
+                                  <span className="2xs:sr-only">Up vote</span>
+                                </button>
+                              )}
+                            <span className="flex 2xs:flex-col">
+                              {Intl.NumberFormat("en-US", {
+                                notation: "compact",
+                                maximumFractionDigits: 3,
+                              }).format(parseFloat(listProposalsData[id].votes))}{" "}
+                              <span className="text-neutral-11 pis-1ex 2xs:pis-0 text-3xs">
+                                vote
+                                {(listProposalsData[id].votes > 1 ||
+                                  listProposalsData[id].votes < -1 ||
+                                  listProposalsData[id].votes === 0) &&
+                                  "s"}
+                              </span>
+                            </span>
+                            {!isProposalDeleted(listProposalsData[id].content) &&
+                              didUserPassSnapshotAndCanVote &&
+                              contestStatus === CONTEST_STATUS.VOTING_OPEN &&
+                              currentUserAvailableVotesAmount > 0 &&
+                              downvotingAllowed === true && (
+                                <button
+                                  onClick={() => onClickDownVote(id)}
+                                  disabled={
+                                    checkIfUserPassedSnapshotLoading ||
+                                    !didUserPassSnapshotAndCanVote ||
+                                    contestStatus !== CONTEST_STATUS.VOTING_OPEN ||
+                                    currentUserAvailableVotesAmount === 0
+                                  }
+                                  className="w-full 2xs:w-auto disabled:text-opacity-50 disabled:cursor-not-allowed disabled:border-none border border-solid border-neutral-5 rounded-md p-2 2xs:p-1.5 flex items-center justify-center"
+                                >
+                                  <IconCaretDown className="text-2xs mie-2 2xs:mie-0" />
+                                  <span className="2xs:sr-only">Down vote</span>
+                                </button>
+                              )}
+                          </div>
+                        </>
                       )}
-                  </div>
-                </li>
-              );
-            })}
-        </ul>
-        {isPageProposalsLoading && Object.keys(listProposalsData)?.length > 1 && <Loader scale="component" classNameWrapper="my-3">
-          Loading proposals...
-        </Loader>}
-        {hasPaginationProposalsNextPage && !isPageProposalsLoading && <div className="pt-8 flex animate-appear">
-          <Button 
-            intent="neutral-outline"
-            scale="sm"
-            className="mx-auto animate-appear"
-            onClick={() => fetchProposalsPage(
-              currentPagePaginationProposals + 1,
-              indexPaginationProposals[currentPagePaginationProposals + 1],
-              totalPagesPaginationProposals
-            )
-          }
-          >
-              {isPageProposalsError ? 'Try again' : 'Show more proposals'}
-          </Button>
-        </div>}
-      </>
+                    </div>
+                    <div className="relative overflow-hidden">
+                      {listProposalsData[id].votes > 0 && (
+                        <span
+                          className={`${styles.rankIndicator} inline-flex 2xs:hidden rounded-full items-center justify-center aspect-square text-opacity-100 mb-3`}
+                        >
+                          #{i + 1}
+                        </span>
+                      )}
+                      <ProposalContent
+                        author={listProposalsData[id].author}
+                        content={
+                          listProposalsData[id].isContentImage
+                            ? listProposalsData[id].content
+                            : truncate(listProposalsData[id].content, 280)
+                        }
+                      />
+                      <Link
+                        href={{
+                          pathname: ROUTE_CONTEST_PROPOSAL,
+                          //@ts-ignore
+                          query: {
+                            chain,
+                            address,
+                            proposal: id,
+                          },
+                        }}
+                      >
+                        <a title={`View proposal #${id}`} className="absolute opacity-0 inset-0 w-full h-full z-10 ">
+                          View proposal #{id}
+                        </a>
+                      </Link>
+                      {!isProposalDeleted(listProposalsData[id].content) &&
+                        contestAuthorEthereumAddress === accountData?.address && (
+                          <button
+                            onClick={() => onClickProposalDelete(id)}
+                            className="w-full 2xs:w-auto mt-6 text-xs 2xs:text-2xs rounded-md py-1.5 2xs:py-1 px-3 relative z-20 bg-negative-4 hover:bg-opacity-50 focus:bg-opacity-75 text-negative-11 bg-opacity-40"
+                          >
+                            <span className="font-bold">Delete this proposal</span>
+                          </button>
+                        )}
+                    </div>
+                  </li>
+                );
+              })}
+          </ul>
+          {isPageProposalsLoading && Object.keys(listProposalsData)?.length > 1 && (
+            <Loader scale="component" classNameWrapper="my-3">
+              Loading proposals...
+            </Loader>
+          )}
+          {Object.keys(listProposalsData)?.length < listProposalsIds && !isPageProposalsLoading && (
+            <div className="pt-8 flex animate-appear">
+              <Button
+                intent="neutral-outline"
+                scale="sm"
+                className="mx-auto animate-appear"
+                onClick={() =>
+                  fetchProposalsPage(
+                    currentPagePaginationProposals + 1,
+                    indexPaginationProposals[currentPagePaginationProposals + 1],
+                    totalPagesPaginationProposals,
+                  )
+                }
+              >
+                {isPageProposalsError ? "Try again" : "Show more proposals"}
+              </Button>
+            </div>
+          )}
+        </>
       );
     }
   }

--- a/packages/react-app-revamp/hooks/useExportContestDataToCSV/store.ts
+++ b/packages/react-app-revamp/hooks/useExportContestDataToCSV/store.ts
@@ -1,6 +1,7 @@
 import create from "zustand";
 
 interface ExportDataState {
+  shouldStart: boolean;
   isReady: boolean;
   isSuccess: boolean;
   isError: boolean;
@@ -14,10 +15,13 @@ interface ExportDataState {
   setIsLoading: (isLoading: boolean) => void;
   setLoadingMessage: (message: string | null) => void;
   setIsReady: (isReady: boolean) => void;
+  setShouldStart: (shouldStart: boolean) => void;
+  resetState: () => void;
 }
 
 export const createExportDataStore = () =>
   create<ExportDataState>(set => ({
+    shouldStart: false,
     csv: null,
     isSuccess: false,
     isError: false,
@@ -31,4 +35,16 @@ export const createExportDataStore = () =>
     setIsLoading: value => set(() => ({ isLoading: value })),
     setIsReady: value => set(() => ({ isReady: value })),
     setLoadingMessage: message => set(() => ({ loadingMessage: message })),
+    setShouldStart: value => set(() => ({ shouldStart: value })),
+    resetState: () =>
+      set(() => ({
+        shouldStart: false,
+        csv: null,
+        isSuccess: false,
+        isError: false,
+        isLoading: false,
+        error: null,
+        loadingMessage: null,
+        isReady: false,
+      })),
   }));

--- a/packages/react-app-revamp/hooks/useExportContestDataToCSV/store.ts
+++ b/packages/react-app-revamp/hooks/useExportContestDataToCSV/store.ts
@@ -1,6 +1,7 @@
 import create from "zustand";
 
 interface ExportDataState {
+  isReady: boolean;
   isSuccess: boolean;
   isError: boolean;
   isLoading: boolean;
@@ -12,6 +13,7 @@ interface ExportDataState {
   setError: (err: string | null, isErr: boolean) => void;
   setIsLoading: (isLoading: boolean) => void;
   setLoadingMessage: (message: string | null) => void;
+  setIsReady: (isReady: boolean) => void;
 }
 
 export const createExportDataStore = () =>
@@ -22,9 +24,11 @@ export const createExportDataStore = () =>
     isLoading: false,
     error: null,
     loadingMessage: null,
+    isReady: false,
     setCsv: data => set(() => ({ csv: data })),
     setIsSuccess: value => set(() => ({ isSuccess: value })),
     setError: (err, isErr) => set(() => ({ error: err, isError: isErr })),
     setIsLoading: value => set(() => ({ isLoading: value })),
+    setIsReady: value => set(() => ({ isReady: value })),
     setLoadingMessage: message => set(() => ({ loadingMessage: message })),
   }));

--- a/packages/react-app-revamp/hooks/useExportContestDataToCSV/useExportContestDataToCSV.ts
+++ b/packages/react-app-revamp/hooks/useExportContestDataToCSV/useExportContestDataToCSV.ts
@@ -78,7 +78,7 @@ export function useExportContestDataToCSV() {
   }
 
   async function formatContestCSVData() {
-    stateExportData.setLoadingMessage(null);
+    stateExportData.setLoadingMessage("Formatting contest data, one moment...");
     stateExportData.setIsLoading(true);
     stateExportData.setIsSuccess(false);
     stateExportData.setCsv(null);

--- a/packages/react-app-revamp/hooks/useExportContestDataToCSV/useExportContestDataToCSV.ts
+++ b/packages/react-app-revamp/hooks/useExportContestDataToCSV/useExportContestDataToCSV.ts
@@ -91,7 +91,7 @@ export function useExportContestDataToCSV() {
       for (let i = 0; i < listProposalsIds.length; i++) {
         const propId = listProposalsIds[i];
         const propTotalVotes = listProposalsData[propId].votes;
-        const propContent = listProposalsData[propId].content;
+        const propContent = listProposalsData[propId]?.content ?? "";
         const proposerAddress = listProposalsData[propId].authorEthereumAddress;
         const addressesVoted = await fetchProposalVoters(propId);
         if (!ensNamesMap.has(proposerAddress)) {


### PR DESCRIPTION
# Description
> Export contest as csv fails after loading 13 proposals

This bug was caused by the pagination. CSV formatting happens in `formatContestCSVData()` which is defined in `hooks/useExportContestDataToCSV` and called in `components/_pages/ButtonDownloadContestDataAsCSV` (we don't load all of the contest data at once anymore but batch by batch, hence why it failed at the 13th proposal since we load proposals 12 by 12).

Now, we ensure that all proposals data are loaded on `ButtonDownloadContestDataAsCSV` mount, and only once all proposals data are loaded (which we track with `isReady` we now `formatContestCSVData()`)  we call `formatContestCSVData()`.

>  if you export a spreadsheet for a contest, it doesn't show the number of votes from each voter per proposal

This bug was caused by the introduction of downvoting (with `proposalAddressVotes()` now returning `forVotes` and `againstVotes`).
Now, we ensure that both pre-downvote contests and contests that implement this ABI return a value with `data?.forVotes ? data?.forVotes / 1e18 - data?.againstVotes / 1e18 : data / 1e18;`

[Video of the bugfix in action](https://www.loom.com/share/857d1a75fbb04ac1926dd9cbd25af3c6)

Should fix #72 

## Screenshots

![Screenshot 2022-09-20 at 11-52-29 JokeDAO 🃏 An open-source collaborative decision-making platform](https://user-images.githubusercontent.com/15010369/191227503-b4a282df-069f-4aa0-b3fc-aec0d7b4539b.png)

![Screenshot 2022-09-20 at 11-52-36 JokeDAO 🃏 An open-source collaborative decision-making platform](https://user-images.githubusercontent.com/15010369/191227541-51ec426e-8ddd-4503-98af-3e035135c492.png)

![Screenshot 2022-09-20 at 11-52-57 JokeDAO 🃏 An open-source collaborative decision-making platform](https://user-images.githubusercontent.com/15010369/191227611-19d9e972-149e-4efd-a234-acbc36878b46.png)

![Screenshot 2022-09-20 at 11-53-10 JokeDAO 🃏 An open-source collaborative decision-making platform](https://user-images.githubusercontent.com/15010369/191227634-129330ba-b21d-4ccc-a2b4-21a0c0f5480e.png)

![Screenshot_20220920_115725](https://user-images.githubusercontent.com/15010369/191228449-7e5e388f-61a2-4cc0-8af6-6b15c4c9307c.png)


## Type of change
[x] Bugfix
