### PR TITLE
feat: add file extension reminder to tiptap/image prompt

### DIFF
--- a/packages/react-app-revamp/components/TipTapEditor/index.tsx
+++ b/packages/react-app-revamp/components/TipTapEditor/index.tsx
@@ -48,7 +48,7 @@ const TipTapEditor = (props: TipTapEditorProps) => {
         </>
       )}
       {showPreview && <TipTapPreview content={editor.getHTML()} />}
-      <div className="my-4">
+      <div className="mt-4">
         <Button
           intent="neutral-outline"
           scale="xs"

--- a/packages/react-app-revamp/components/TipTapEditorControls/index.tsx
+++ b/packages/react-app-revamp/components/TipTapEditorControls/index.tsx
@@ -292,7 +292,7 @@ export const TipTapEditorControls = (props: TipTapEditorControlsProps) => {
         type="button"
         className={`${styles.control} ${editor.isActive("image") ? styles["control--active"] : ""}`}
         onClick={() => {
-          const url = window.prompt("Image URL");
+          const url = window.prompt("Your image URL (must end with a valid image extension like .png, .jpeg, .gif ...).");
 
           if (url) {
             editor

--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
@@ -173,6 +173,7 @@ export const DialogModalSendProposal = (props: DialogModalSendProposalProps) => 
             <>
               <form className={isLoading === true ? "opacity-50 pointer-events-none" : ""} onSubmit={onSubmitProposal}>
                 <TipTapEditor editor={editorProposal} />
+                <p className="mt-2 text-neutral-11 text-3xs">Make sure to preview your proposal to check if it renders properly !</p>
                 <Button
                   disabled={proposal.trim().length === 0 || isLoading}
                   type="submit"


### PR DESCRIPTION
# Description
> Some submissions contain images that don’t render. To prevent this, we should add instructions for the image or at least specify “link *must* end in .png or .jpeg”

* feat: add additional instruction `(must end with a valid image extension like .png, .jpeg, .gif ...)` in `window.prompt` of tiptap image extension 
* feat: add to toggle preview in `DialogModalSendProposal`

## Screenshots

![Screenshot_20220926_105440](https://user-images.githubusercontent.com/15010369/192236616-e1d14b27-17f0-4818-af97-6bdc538b102e.png)

![Screenshot_20220926_105452](https://user-images.githubusercontent.com/15010369/192236620-c5978f71-e3d6-4dfc-9e97-aaa56041b958.png)


## Type of change
- [x] Feature (non-breaking changes) - UX improvement