### PR TITLE
bugfix: only update votes live for hour before close

### DIFF
--- a/packages/react-app-revamp/hooks/useCastVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useCastVotes/index.ts
@@ -4,7 +4,7 @@ import DeployedContestContract from "@contracts/bytecodeAndAbi/Contest.sol/Conte
 import { useStore as useStoreCastVotes } from "./store";
 import { useNetwork } from "wagmi";
 import { useRouter } from "next/router";
-import { parseEther, parseUnits } from "ethers/lib/utils";
+import { parseUnits } from "ethers/lib/utils";
 import useContest from "@hooks/useContest";
 import getContestContractVersion from "@helpers/getContestContractVersion";
 

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -6,7 +6,7 @@ import { fetchBlockNumber, fetchEnsName, fetchToken, getAccount, readContract, r
 import { chains } from "@config/wagmi";
 import isUrlToImage from "@helpers/isUrlToImage";
 import { useStore } from "./store";
-import { addHours, differenceInHours, differenceInMilliseconds, hoursToMilliseconds, isBefore, isFuture } from "date-fns";
+import { differenceInHours, differenceInMilliseconds, hoursToMilliseconds, isBefore, isFuture } from "date-fns";
 import { CONTEST_STATUS } from "@helpers/contestStatus";
 import getContestContractVersion from "@helpers/getContestContractVersion";
 import useContestsIndex from "@hooks/useContestsIndex";

--- a/packages/react-app-revamp/hooks/useContest/store.ts
+++ b/packages/react-app-revamp/hooks/useContest/store.ts
@@ -36,7 +36,6 @@ export const createStore = () => {
     currentUserProposalCount: 0,
     downvotingAllowed: false,
     currentUserSubmitProposalTokensAmount: null,
-
     isPageProposalsLoading: false,
     isPageProposalsError: null,
     isPageProposalSuccess: false,
@@ -44,6 +43,8 @@ export const createStore = () => {
     totalPagesPaginationProposals: 0,
     currentPagePaginationProposals: 0,
     hasPaginationProposalsNextPage: false,
+    canUpdateVotesInRealTime: false,
+    setCanUpdateVotesInRealTime: (value: boolean) => set({ canUpdateVotesInRealTime: value }),
     setIsPageProposalsLoading: (value: boolean) => set({ isPageProposalsLoading: value }),
     setIsPageProposalsSuccess: (value: boolean) => set({ isPageProposalsSuccess: value }),
     setIsPageProposalsError: (value: boolean) => set({ isPageProposalsError: value }),

--- a/packages/react-app-revamp/hooks/useContestEvents/index.ts
+++ b/packages/react-app-revamp/hooks/useContestEvents/index.ts
@@ -1,7 +1,7 @@
 import isUrlToImage from "@helpers/isUrlToImage";
 import { chain, fetchEnsName, getAccount, readContract } from "@wagmi/core";
 import { useRouter } from "next/router";
-import { useContractEvent } from "wagmi";
+import { useContractEvent, useContract, useProvider } from "wagmi";
 import DeployedContestContract from "@contracts/bytecodeAndAbi/Contest.sol/Contest.json";
 import { useStore as useStoreSubmitProposal } from "../useSubmitProposal/store";
 import { useStore as useStoreContest } from "../useContest/store";
@@ -10,6 +10,7 @@ import useContest from "@hooks/useContest";
 
 export function useContestEvents() {
   const { asPath } = useRouter();
+  const provider = useProvider();
   const storeSubmitProposal = useStoreSubmitProposal();
   const {
     //@ts-ignore
@@ -26,6 +27,13 @@ export function useContestEvents() {
     votesClose,
   } = useStoreContest();
   const { updateCurrentUserVotes } = useContest();
+  const {
+    removeAllListeners
+  } = useContract({
+    addressOrName: asPath.split("/")[3],
+    contractInterface: DeployedContestContract.abi,
+    signerOrProvider: provider
+  })
 
   // useContractEvent({
   //   addressOrName: asPath.split("/")[3],
@@ -121,6 +129,10 @@ export function useContestEvents() {
       },
     });
   };
+
+  if (isAfter(new Date(), votesClose)) {
+    removeAllListeners();
+  }
 
   function updateProposalTransactionData(transactionHash: string, proposalId: string | number) {
     //@ts-ignore

--- a/packages/react-app-revamp/hooks/useContestEvents/index.ts
+++ b/packages/react-app-revamp/hooks/useContestEvents/index.ts
@@ -5,6 +5,7 @@ import { useContractEvent } from "wagmi";
 import DeployedContestContract from "@contracts/bytecodeAndAbi/Contest.sol/Contest.json";
 import { useStore as useStoreSubmitProposal } from "../useSubmitProposal/store";
 import { useStore as useStoreContest } from "../useContest/store";
+import { hoursToMilliseconds, isAfter, isBefore, isEqual } from "date-fns";
 import useContest from "@hooks/useContest";
 
 export function useContestEvents() {
@@ -21,6 +22,8 @@ export function useContestEvents() {
     softDeleteProposal,
     //@ts-ignore
     listProposalsData,
+    //@ts-ignore
+    votesClose,
   } = useStoreContest();
   const { updateCurrentUserVotes } = useContest();
 
@@ -63,59 +66,61 @@ export function useContestEvents() {
   //   },
   // });
 
-  // useContractEvent({
-  //   addressOrName: asPath.split("/")[3],
-  //   contractInterface: DeployedContestContract.abi,
-  //   eventName: "VoteCast",
+  if (isAfter(new Date(), votesClose - hoursToMilliseconds(1)) || isBefore(new Date(), votesClose) || isEqual(new Date(), votesClose)) {
+    useContractEvent({
+      addressOrName: asPath.split("/")[3],
+      contractInterface: DeployedContestContract.abi,
+      eventName: "VoteCast",
 
-  //   listener: async event => {
-  //     const accountData = await getAccount();
-  //     // if the connected wallet is the address that casted votes
-  //     if (accountData?.address && event[0] === accountData?.address) {
-  //       // Update the current user available votes
-  //       updateCurrentUserVotes();
-  //     }
+      listener: async event => {
+        const accountData = await getAccount();
+        // if the connected wallet is the address that casted votes
+        if (accountData?.address && event[0] === accountData?.address) {
+          // Update the current user available votes
+          updateCurrentUserVotes();
+        }
 
-  //     const proposalId = event[5].args.proposalId;
-  //     const votes = await readContract({
-  //       addressOrName: asPath.split("/")[3],
-  //       contractInterface: DeployedContestContract.abi,
-  //       functionName: "proposalVotes",
-  //       args: proposalId,
-  //     });
+        const proposalId = event[5].args.proposalId;
+        const votes = await readContract({
+          addressOrName: asPath.split("/")[3],
+          contractInterface: DeployedContestContract.abi,
+          functionName: "proposalVotes",
+          args: proposalId,
+        });
 
-  //     if (listProposalsData[proposalId]) {
-  //       //@ts-ignore
-  //       setProposalVotes({
-  //         id: proposalId,
-  //         //@ts-ignore
-  //         votes: votes?.forVotes ? votes?.forVotes / 1e18 - votes?.againstVotes / 1e18 : votes / 1e18,
-  //       });
-  //     } else {
-  //       const proposal = await readContract({
-  //         addressOrName: asPath.split("/")[3],
-  //         contractInterface: DeployedContestContract.abi,
-  //         functionName: "getProposal",
-  //         args: proposalId,
-  //       });
-  //       const author = await fetchEnsName({
-  //         address: proposal[0],
-  //         chainId: chain.mainnet.id,
-  //       });
-  //       const proposalData: any = {
-  //         authorEthereumAddress: proposal[0],
-  //         author: author ?? proposal[0],
-  //         content: proposal[1],
-  //         isContentImage: isUrlToImage(proposal[1]) ? true : false,
-  //         exists: proposal[2],
-  //         //@ts-ignore
-  //         votes: votes?.forVotes ? votes?.forVotes / 1e18 - votes?.againstVotes / 1e18 : votes / 1e18,
-  //       };
+        if (listProposalsData[proposalId]) {
+          //@ts-ignore
+          setProposalVotes({
+            id: proposalId,
+            //@ts-ignore
+            votes: votes?.forVotes ? votes?.forVotes / 1e18 - votes?.againstVotes / 1e18 : votes / 1e18,
+          });
+        } else {
+          const proposal = await readContract({
+            addressOrName: asPath.split("/")[3],
+            contractInterface: DeployedContestContract.abi,
+            functionName: "getProposal",
+            args: proposalId,
+          });
+          const author = await fetchEnsName({
+            address: proposal[0],
+            chainId: chain.mainnet.id,
+          });
+          const proposalData: any = {
+            authorEthereumAddress: proposal[0],
+            author: author ?? proposal[0],
+            content: proposal[1],
+            isContentImage: isUrlToImage(proposal[1]) ? true : false,
+            exists: proposal[2],
+            //@ts-ignore
+            votes: votes?.forVotes ? votes?.forVotes / 1e18 - votes?.againstVotes / 1e18 : votes / 1e18,
+          };
 
-  //       setProposalData({ id: proposalId, data: proposalData });
-  //     }
-  //   },
-  // });
+          setProposalData({ id: proposalId, data: proposalData });
+        }
+      },
+    });
+  };
 
   function updateProposalTransactionData(transactionHash: string, proposalId: string | number) {
     //@ts-ignore

--- a/packages/react-app-revamp/hooks/useContestEvents/index.ts
+++ b/packages/react-app-revamp/hooks/useContestEvents/index.ts
@@ -32,7 +32,6 @@ export function useContestEvents() {
   } = useContract({
     addressOrName: asPath.split("/")[3],
     contractInterface: DeployedContestContract.abi,
-    signerOrProvider: provider
   })
 
   // useContractEvent({

--- a/packages/react-app-revamp/hooks/useContestEvents/index.ts
+++ b/packages/react-app-revamp/hooks/useContestEvents/index.ts
@@ -6,11 +6,8 @@ import { useStore as useStoreContest } from "../useContest/store";
 import useContest from "@hooks/useContest";
 import { useEffect } from "react";
 import { CONTEST_STATUS } from "@helpers/contestStatus";
-
 /*
-import { useContractEvent, useContract, useProvider } from "wagmi";
-import { useStore as useStoreSubmitProposal } from "../useSubmitProposal/store";
-import { hoursToMilliseconds, isAfter, isBefore, isEqual } from "date-fns";
+import { useContractEvent } from "wagmi";
 import { useStore as useStoreSubmitProposal } from "../useSubmitProposal/store";
 */
 
@@ -112,44 +109,8 @@ export function useContestEvents() {
     }
 
   }, [canUpdateVotesInRealTime, contestStatus])
+  
   /*
-  const {
-    removeAllListeners
-  } = useContract({
-    addressOrName: asPath.split("/")[3],
-    contractInterface: DeployedContestContract.abi,
-  })
-
-  useContractEvent({
-    addressOrName: asPath.split("/")[3],
-    contractInterface: DeployedContestContract.abi,
-    eventName: "ProposalCreated",
-    listener: async event => {
-      const proposalContent = event[3].args.description;
-      const proposalAuthor = event[3].args.proposer;
-      const proposalId = event[3].args.proposalId.toString();
-
-      const author = await fetchEnsName({
-        address: proposalAuthor,
-        chainId: chain.mainnet.id,
-      });
-
-      const proposalData = {
-        author: author ?? proposalAuthor,
-        content: proposalContent,
-        isContentImage: isUrlToImage(proposalContent) ? true : false,
-        exists: true,
-        //@ts-ignore
-        votes: 0,
-      };
-
-      addProposalId(proposalId);
-      setProposalData({ id: proposalId, data: proposalData });
-
-      updateProposalTransactionData(event[3].transactionHash, proposalId);
-    },
-  });
-
   useContractEvent({
     addressOrName: asPath.split("/")[3],
     contractInterface: DeployedContestContract.abi,
@@ -158,66 +119,6 @@ export function useContestEvents() {
       softDeleteProposal(event[0].toString());
     },
   });
-  
-  if (isAfter(new Date(), votesClose - hoursToMilliseconds(1)) || isBefore(new Date(), votesClose) || isEqual(new Date(), votesClose)) {
-    useContractEvent({
-      addressOrName: asPath.split("/")[3],
-      contractInterface: DeployedContestContract.abi,
-      eventName: "VoteCast",
-
-      listener: async event => {
-        const accountData = await getAccount();
-        // if the connected wallet is the address that casted votes
-        if (accountData?.address && event[0] === accountData?.address) {
-          // Update the current user available votes
-          updateCurrentUserVotes();
-        }
-
-        const proposalId = event[5].args.proposalId;
-        const votes = await readContract({
-          addressOrName: asPath.split("/")[3],
-          contractInterface: DeployedContestContract.abi,
-          functionName: "proposalVotes",
-          args: proposalId,
-        });
-
-        if (listProposalsData[proposalId]) {
-          //@ts-ignore
-          setProposalVotes({
-            id: proposalId,
-            //@ts-ignore
-            votes: votes?.forVotes ? votes?.forVotes / 1e18 - votes?.againstVotes / 1e18 : votes / 1e18,
-          });
-        } else {
-          const proposal = await readContract({
-            addressOrName: asPath.split("/")[3],
-            contractInterface: DeployedContestContract.abi,
-            functionName: "getProposal",
-            args: proposalId,
-          });
-          const author = await fetchEnsName({
-            address: proposal[0],
-            chainId: chain.mainnet.id,
-          });
-          const proposalData: any = {
-            authorEthereumAddress: proposal[0],
-            author: author ?? proposal[0],
-            content: proposal[1],
-            isContentImage: isUrlToImage(proposal[1]) ? true : false,
-            exists: proposal[2],
-            //@ts-ignore
-            votes: votes?.forVotes ? votes?.forVotes / 1e18 - votes?.againstVotes / 1e18 : votes / 1e18,
-          };
-
-          setProposalData({ id: proposalId, data: proposalData });
-        }
-      },
-    });
-  };
-
-  if (isAfter(new Date(), votesClose)) {
-    removeAllListeners();
-  }
   
   useContractEvent({
     addressOrName: asPath.split("/")[3],
@@ -248,16 +149,6 @@ export function useContestEvents() {
       updateProposalTransactionData(event[3].transactionHash, proposalId);
     },
   });
-
-  useContractEvent({
-    addressOrName: asPath.split("/")[3],
-    contractInterface: DeployedContestContract.abi,
-    eventName: "ProposalsDeleted",
-    listener: async event => {
-      softDeleteProposal(event[0].toString());
-    },
-  });
-
 
   function updateProposalTransactionData(transactionHash: string, proposalId: string | number) {
     //@ts-ignore

--- a/packages/react-app-revamp/hooks/useContestEvents/index.ts
+++ b/packages/react-app-revamp/hooks/useContestEvents/index.ts
@@ -1,32 +1,118 @@
 import isUrlToImage from "@helpers/isUrlToImage";
-import { chain, fetchEnsName, getAccount, readContract } from "@wagmi/core";
+import { chain, fetchEnsName, getAccount, readContract, getContract, watchContractEvent } from "@wagmi/core";
 import { useRouter } from "next/router";
-import { useContractEvent, useContract, useProvider } from "wagmi";
 import DeployedContestContract from "@contracts/bytecodeAndAbi/Contest.sol/Contest.json";
-import { useStore as useStoreSubmitProposal } from "../useSubmitProposal/store";
 import { useStore as useStoreContest } from "../useContest/store";
-import { hoursToMilliseconds, isAfter, isBefore, isEqual } from "date-fns";
 import useContest from "@hooks/useContest";
+import { useEffect } from "react";
+import { CONTEST_STATUS } from "@helpers/contestStatus";
+
+/*
+import { useContractEvent, useContract, useProvider } from "wagmi";
+import { useStore as useStoreSubmitProposal } from "../useSubmitProposal/store";
+import { hoursToMilliseconds, isAfter, isBefore, isEqual } from "date-fns";
+import { useStore as useStoreSubmitProposal } from "../useSubmitProposal/store";
+*/
 
 export function useContestEvents() {
   const { asPath } = useRouter();
-  const provider = useProvider();
-  const storeSubmitProposal = useStoreSubmitProposal();
+  // const storeSubmitProposal = useStoreSubmitProposal();
   const {
+    //@ts-ignore
+    contestStatus,
     //@ts-ignore
     setProposalData,
     //@ts-ignore
-    addProposalId,
-    //@ts-ignore
     setProposalVotes,
-    //@ts-ignore,
-    softDeleteProposal,
     //@ts-ignore
     listProposalsData,
     //@ts-ignore
-    votesClose,
+    canUpdateVotesInRealTime,
   } = useStoreContest();
   const { updateCurrentUserVotes } = useContest();
+
+  /**
+   * Callback function triggered on "VoteCast" event
+   * @param args - Array of the following values: from, to, value, event|event[]
+   */
+  async function onVoteCast(args: Array<any>) {
+    try {
+      const accountData = await getAccount();
+      // if the connected wallet is the address that casted votes
+      if (accountData?.address && args[0] === accountData?.address) {
+        // Update the current user available votes
+        updateCurrentUserVotes();
+      }
+  
+      const proposalId = args[5].args.proposalId;
+      const votes = await readContract({
+        addressOrName: asPath.split("/")[3],
+        contractInterface: DeployedContestContract.abi,
+        functionName: "proposalVotes",
+        args: proposalId,
+      });
+  
+      if (listProposalsData[proposalId]) {
+        //@ts-ignore
+        setProposalVotes({
+          id: proposalId,
+          //@ts-ignore
+          votes: votes?.forVotes ? votes?.forVotes / 1e18 - votes?.againstVotes / 1e18 : votes / 1e18,
+        });
+      } else {
+        const proposal = await readContract({
+          addressOrName: asPath.split("/")[3],
+          contractInterface: DeployedContestContract.abi,
+          functionName: "getProposal",
+          args: proposalId,
+        });
+        const author = await fetchEnsName({
+          address: proposal[0],
+          chainId: chain.mainnet.id,
+        });
+        const proposalData: any = {
+          authorEthereumAddress: proposal[0],
+          author: author ?? proposal[0],
+          content: proposal[1],
+          isContentImage: isUrlToImage(proposal[1]) ? true : false,
+          exists: proposal[2],
+          //@ts-ignore
+          votes: votes?.forVotes ? votes?.forVotes / 1e18 - votes?.againstVotes / 1e18 : votes / 1e18,
+        };
+  
+        setProposalData({ id: proposalId, data: proposalData });
+      }
+  
+    } catch(e) {
+      console.error(e)
+    }
+  }
+
+  useEffect(() => {
+    if(canUpdateVotesInRealTime === true) {
+          // Only watch VoteCast events when voting is open and we are <=1h before end of voting
+        if(contestStatus === CONTEST_STATUS.VOTING_OPEN) {
+        watchContractEvent({
+          addressOrName: asPath.split("/")[3],
+          contractInterface: DeployedContestContract.abi,
+        }, 
+        "VoteCast", (...args) => {
+          onVoteCast(args)
+        })
+      }
+      // When voting closes, remove all event listeners
+      if(contestStatus === CONTEST_STATUS.COMPLETED) {
+        const contract = getContract({
+          addressOrName: asPath.split("/")[3],
+          contractInterface: DeployedContestContract.abi,
+  
+        })
+        contract.removeAllListeners()
+      }
+    }
+
+  }, [canUpdateVotesInRealTime, contestStatus])
+  /*
   const {
     removeAllListeners
   } = useContract({
@@ -34,45 +120,45 @@ export function useContestEvents() {
     contractInterface: DeployedContestContract.abi,
   })
 
-  // useContractEvent({
-  //   addressOrName: asPath.split("/")[3],
-  //   contractInterface: DeployedContestContract.abi,
-  //   eventName: "ProposalCreated",
-  //   listener: async event => {
-  //     const proposalContent = event[3].args.description;
-  //     const proposalAuthor = event[3].args.proposer;
-  //     const proposalId = event[3].args.proposalId.toString();
+  useContractEvent({
+    addressOrName: asPath.split("/")[3],
+    contractInterface: DeployedContestContract.abi,
+    eventName: "ProposalCreated",
+    listener: async event => {
+      const proposalContent = event[3].args.description;
+      const proposalAuthor = event[3].args.proposer;
+      const proposalId = event[3].args.proposalId.toString();
 
-  //     const author = await fetchEnsName({
-  //       address: proposalAuthor,
-  //       chainId: chain.mainnet.id,
-  //     });
+      const author = await fetchEnsName({
+        address: proposalAuthor,
+        chainId: chain.mainnet.id,
+      });
 
-  //     const proposalData = {
-  //       author: author ?? proposalAuthor,
-  //       content: proposalContent,
-  //       isContentImage: isUrlToImage(proposalContent) ? true : false,
-  //       exists: true,
-  //       //@ts-ignore
-  //       votes: 0,
-  //     };
+      const proposalData = {
+        author: author ?? proposalAuthor,
+        content: proposalContent,
+        isContentImage: isUrlToImage(proposalContent) ? true : false,
+        exists: true,
+        //@ts-ignore
+        votes: 0,
+      };
 
-  //     addProposalId(proposalId);
-  //     setProposalData({ id: proposalId, data: proposalData });
+      addProposalId(proposalId);
+      setProposalData({ id: proposalId, data: proposalData });
 
-  //     updateProposalTransactionData(event[3].transactionHash, proposalId);
-  //   },
-  // });
+      updateProposalTransactionData(event[3].transactionHash, proposalId);
+    },
+  });
 
-  // useContractEvent({
-  //   addressOrName: asPath.split("/")[3],
-  //   contractInterface: DeployedContestContract.abi,
-  //   eventName: "ProposalsDeleted",
-  //   listener: async event => {
-  //     softDeleteProposal(event[0].toString());
-  //   },
-  // });
-
+  useContractEvent({
+    addressOrName: asPath.split("/")[3],
+    contractInterface: DeployedContestContract.abi,
+    eventName: "ProposalsDeleted",
+    listener: async event => {
+      softDeleteProposal(event[0].toString());
+    },
+  });
+  
   if (isAfter(new Date(), votesClose - hoursToMilliseconds(1)) || isBefore(new Date(), votesClose) || isEqual(new Date(), votesClose)) {
     useContractEvent({
       addressOrName: asPath.split("/")[3],
@@ -132,6 +218,46 @@ export function useContestEvents() {
   if (isAfter(new Date(), votesClose)) {
     removeAllListeners();
   }
+  
+  useContractEvent({
+    addressOrName: asPath.split("/")[3],
+    contractInterface: DeployedContestContract.abi,
+    eventName: "ProposalCreated",
+    listener: async event => {
+      const proposalContent = event[3].args.description;
+      const proposalAuthor = event[3].args.proposer;
+      const proposalId = event[3].args.proposalId.toString();
+
+      const author = await fetchEnsName({
+        address: proposalAuthor,
+        chainId: chain.mainnet.id,
+      });
+
+      const proposalData = {
+        author: author ?? proposalAuthor,
+        content: proposalContent,
+        isContentImage: isUrlToImage(proposalContent) ? true : false,
+        exists: true,
+        //@ts-ignore
+        votes: 0,
+      };
+
+      addProposalId(proposalId);
+      setProposalData({ id: proposalId, data: proposalData });
+
+      updateProposalTransactionData(event[3].transactionHash, proposalId);
+    },
+  });
+
+  useContractEvent({
+    addressOrName: asPath.split("/")[3],
+    contractInterface: DeployedContestContract.abi,
+    eventName: "ProposalsDeleted",
+    listener: async event => {
+      softDeleteProposal(event[0].toString());
+    },
+  });
+
 
   function updateProposalTransactionData(transactionHash: string, proposalId: string | number) {
     //@ts-ignore
@@ -144,6 +270,7 @@ export function useContestEvents() {
       });
     }
   }
+  */
 }
 
 export default useContestEvents;

--- a/packages/react-app-revamp/hooks/useProposalVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useProposalVotes/index.ts
@@ -83,7 +83,6 @@ export function useProposalVotes(id: number | string) {
   } = useContract({
     addressOrName: asPath.split("/")[3],
     contractInterface: DeployedContestContract.abi,
-    signerOrProvider: provider
   })
 
   /**

--- a/packages/react-app-revamp/hooks/useProposalVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useProposalVotes/index.ts
@@ -8,8 +8,10 @@ import DeployedContestContract from "@contracts/bytecodeAndAbi/Contest.sol/Conte
 import { chains } from "@config/wagmi";
 import shortenEthereumAddress from "@helpers/shortenEthereumAddress";
 import { useStore } from "./store";
+import { useStore as useStoreContest } from "../useContest/store";
 import getContestContractVersion from "@helpers/getContestContractVersion";
 import arrayToChunks from "@helpers/arrayToChunks";
+import { hoursToMilliseconds, isAfter, isBefore, isEqual } from "date-fns";
 
 const VOTES_PER_PAGE = 5;
 
@@ -71,6 +73,10 @@ export function useProposalVotes(id: number | string) {
     }),
     shallow,
   );
+  const {
+    //@ts-ignore
+    votesClose,
+  } = useStoreContest();
 
   /**
    * Fetch all votes of a given proposals (amount of votes, + detailed list of voters and the amount of votes they casted)

--- a/packages/react-app-revamp/hooks/useProposalVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useProposalVotes/index.ts
@@ -2,17 +2,15 @@ import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import { useRouter } from "next/router";
 import shallow from "zustand/shallow";
-import { chain as wagmiChain, useAccount, useContractEvent, useContract, useProvider } from "wagmi";
+import { chain as wagmiChain, useAccount } from "wagmi";
 import { getContract, watchContractEvent } from "@wagmi/core"
 import { fetchEnsName, getAccount, readContract } from "@wagmi/core";
 import DeployedContestContract from "@contracts/bytecodeAndAbi/Contest.sol/Contest.json";
 import { chains } from "@config/wagmi";
 import shortenEthereumAddress from "@helpers/shortenEthereumAddress";
 import { useStore } from "./store";
-import { useStore as useStoreContest } from "../useContest/store";
 import getContestContractVersion from "@helpers/getContestContractVersion";
 import arrayToChunks from "@helpers/arrayToChunks";
-import { hoursToMilliseconds, isAfter, isBefore, isEqual } from "date-fns";
 import { CONTEST_STATUS } from "@helpers/contestStatus";
 
 const VOTES_PER_PAGE = 5;
@@ -82,15 +80,6 @@ export function useProposalVotes(id: number | string) {
     }),
     shallow,
   );
-
-  /*
-  const {
-    removeAllListeners
-  } = useContract({
-    addressOrName: asPath.split("/")[3],
-    contractInterface: DeployedContestContract.abi,
-  })
-  */
 
   /**
    * Fetch all votes of a given proposals (amount of votes, + detailed list of voters and the amount of votes they casted)
@@ -265,23 +254,6 @@ export function useProposalVotes(id: number | string) {
   useEffect(() => {
     fetchProposalVotes();
   }, []);
-
-  /*
-  if (isAfter(new Date(), votesClose - hoursToMilliseconds(1)) || isBefore(new Date(), votesClose) || isEqual(new Date(), votesClose)) {
-    useContractEvent({
-      addressOrName: asPath.split("/")[3],
-      contractInterface: DeployedContestContract.abi,
-      eventName: "VoteCast",
-      listener: event => {
-        fetchVotesOfAddress(event[0]);
-      },
-    });
-  };
-
-  if (isAfter(new Date(), votesClose)) {
-    removeAllListeners();
-  }
-  */
 
   return {
     isLoading: isListVotersLoading,


### PR DESCRIPTION
# Description
> In order to save RPC calls which are costing us a significant amount of money currently we will only update votes live for hour before voting closes on a contest.

Using [`removeAllListeners()`](https://docs.ethers.io/v5/api/contract/contract/) in `ethers` to turn off the monitoring once the voting period is over.

TODO: How can I call `useContract()` like we do `useContractEvents()`, without a provider? (and note - even when I do use `useProvider()` and am connected it still errors saying that the provider is undefined, I think somewhere I'm not plugging into wagmi context correctly)

Also we should use a timer for the time until the vote closes (if we are still in the voting period that is) instead of just an if statement to remove the listeners so we leave nothing to chance (currently implemented, if a user never reloaded their page after the voting period ended, the listeners would not be removed).