### PR TITLE
feat: display lens profile

### DIFF
--- a/packages/react-app-revamp/codegen.yaml
+++ b/packages/react-app-revamp/codegen.yaml
@@ -1,0 +1,12 @@
+schema: 'https://api.lens.dev'
+documents: './graphql/*.graphql'
+generates:
+  ./graphql/generated.ts:
+    plugins:
+      - typescript
+      - typescript-operations
+      - typed-document-node
+      - fragment-matcher
+    config:
+      fetcher: fetch
+      dedupeFragments: true

--- a/packages/react-app-revamp/components/EtheuremAddress/index.tsx
+++ b/packages/react-app-revamp/components/EtheuremAddress/index.tsx
@@ -37,10 +37,11 @@ export const EtheuremAddress = (props: EtheuremAddressProps) => {
   });
 
   if (!displayLensProfile || queryUserProfileLens?.status === "error" || queryUserProfileLens?.data === null) {
-    if (queryEns?.status === "success" && queryEns?.data !== null) return `${withHyphen === true ? "— " : ""}${queryEns?.data}`
-    return shortenOnFallback === true
+    if (queryEns?.status === "success" && queryEns?.data !== null) return <>{`${withHyphen === true ? "— " : ""}${queryEns?.data}`}</>
+    return <>{shortenOnFallback === true
       ? `${withHyphen === true ? "— " : ""}${shortenEthereumAddress(ethereumAddress)}`
-      : `${withHyphen === true ? "— " : ""}${ethereumAddress}`;
+      : `${withHyphen === true ? "— " : ""}${ethereumAddress}`}
+      </>
   }
 
   if (queryUserProfileLens?.status === "loading")
@@ -76,6 +77,7 @@ export const EtheuremAddress = (props: EtheuremAddressProps) => {
         </a>
       </span>
     );
+    return <>{ethereumAddress}</>
 };
 
 export default EtheuremAddress;

--- a/packages/react-app-revamp/components/EtheuremAddress/index.tsx
+++ b/packages/react-app-revamp/components/EtheuremAddress/index.tsx
@@ -1,0 +1,82 @@
+import { useQuery } from "@tanstack/react-query";
+import { getDefaultProfile } from "@services/lens/getDefaultProfile";
+import { shortenEthereumAddress } from "@helpers/shortenEthereumAddress";
+import { chain, useEnsName } from "wagmi";
+
+interface EtheuremAddressProps {
+  ethereumAddress: string;
+  shortenOnFallback: boolean;
+  displayLensProfile: boolean;
+  withHyphen: boolean;
+}
+export const EtheuremAddress = (props: EtheuremAddressProps) => {
+  const { ethereumAddress, displayLensProfile, shortenOnFallback, withHyphen } = props;
+  const queryUserProfileLens = useQuery(
+    ["lens-profile", ethereumAddress],
+    async () => {
+      try {
+        const result = await getDefaultProfile({
+          ethereumAddress,
+        });
+        //@ts-ignore
+        if (result?.error) throw new Error(result?.error);
+        return result?.data?.defaultProfile;
+      } catch (e) {
+        console.error(e);
+      }
+    },
+    {
+      enabled: displayLensProfile,
+    },
+  );
+
+  const queryEns = useEnsName({
+    chainId: chain.mainnet.id,
+    address: ethereumAddress,
+    enabled: queryUserProfileLens?.isSuccess && queryUserProfileLens?.data === null ? true : false,
+  });
+  console.log(queryEns?.data);
+
+  if (!displayLensProfile || queryUserProfileLens?.status === "error" || queryUserProfileLens?.data === null) {
+    if (queryEns?.status === "success" && queryEns?.data !== null) return queryEns?.data;
+    return shortenOnFallback === true
+      ? `${withHyphen ? "— " : ""}${shortenEthereumAddress(ethereumAddress)}`
+      : `${withHyphen ? "— " : ""}${ethereumAddress}`;
+  }
+
+  if (queryUserProfileLens?.status === "loading")
+    return <>Loading {shortenEthereumAddress(ethereumAddress)} profile data...</>;
+  if (queryUserProfileLens?.status === "success" && queryUserProfileLens?.data !== null)
+    return (
+      <span className="flex items-baseline 2xs:items-center">
+        {withHyphen ? "—" : ""}
+        <a
+          title={`View ${queryUserProfileLens?.data?.name}'s profile on LensFrens`}
+          className={`relative flex flex-col 2xs:flex-row 2xs:items-center flex-grow z-20 ${withHyphen ? "pis-3" : ""}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          href={`https://lensfrens.xyz/${queryUserProfileLens?.data?.handle}`}
+        >
+          {queryUserProfileLens?.data?.picture?.original?.url && (
+            <div className="shrink-0 w-10 h-10 mb-3 2xs:mb-0 2xs:mie-3 bg-neutral-5 rounded-full overflow-hidden">
+              <img
+                className="w-full h-full object-cover"
+                src={queryUserProfileLens?.data?.picture?.original?.url?.replace(
+                  "ipfs://",
+                  "https://lens.infura-ipfs.io/ipfs/",
+                )}
+                alt=""
+              />
+            </div>
+          )}
+
+          <span className="flex flex-wrap whitespace-pre-line">
+            <span className="font-bold w-full">{queryUserProfileLens?.data?.name}&nbsp;</span>
+            <span className="text-[0.9em] opacity-50">@{queryUserProfileLens?.data?.handle}</span>
+          </span>
+        </a>
+      </span>
+    );
+};
+
+export default EtheuremAddress;

--- a/packages/react-app-revamp/components/EtheuremAddress/index.tsx
+++ b/packages/react-app-revamp/components/EtheuremAddress/index.tsx
@@ -33,7 +33,7 @@ export const EtheuremAddress = (props: EtheuremAddressProps) => {
   const queryEns = useEnsName({
     chainId: chain.mainnet.id,
     address: ethereumAddress,
-    enabled: (queryUserProfileLens?.isSuccess || queryUserProfileLens?.isError) && queryUserProfileLens?.data === null ? true : false,
+    enabled: (queryUserProfileLens?.isSuccess && queryUserProfileLens?.data === null ) || queryUserProfileLens?.isError  ? true : false,
   });
 
   if (!displayLensProfile || queryUserProfileLens?.status === "error" || queryUserProfileLens?.data === null) {

--- a/packages/react-app-revamp/components/EtheuremAddress/index.tsx
+++ b/packages/react-app-revamp/components/EtheuremAddress/index.tsx
@@ -33,7 +33,7 @@ export const EtheuremAddress = (props: EtheuremAddressProps) => {
   const queryEns = useEnsName({
     chainId: chain.mainnet.id,
     address: ethereumAddress,
-    enabled: queryUserProfileLens?.isSuccess && queryUserProfileLens?.data === null ? true : false,
+    enabled: (queryUserProfileLens?.isSuccess || queryUserProfileLens?.isError) && queryUserProfileLens?.data === null ? true : false,
   });
 
   if (!displayLensProfile || queryUserProfileLens?.status === "error" || queryUserProfileLens?.data === null) {

--- a/packages/react-app-revamp/components/EtheuremAddress/index.tsx
+++ b/packages/react-app-revamp/components/EtheuremAddress/index.tsx
@@ -35,13 +35,12 @@ export const EtheuremAddress = (props: EtheuremAddressProps) => {
     address: ethereumAddress,
     enabled: queryUserProfileLens?.isSuccess && queryUserProfileLens?.data === null ? true : false,
   });
-  console.log(queryEns?.data);
 
   if (!displayLensProfile || queryUserProfileLens?.status === "error" || queryUserProfileLens?.data === null) {
-    if (queryEns?.status === "success" && queryEns?.data !== null) return queryEns?.data;
+    if (queryEns?.status === "success" && queryEns?.data !== null) return `${withHyphen === true ? "— " : ""}${queryEns?.data}`
     return shortenOnFallback === true
-      ? `${withHyphen ? "— " : ""}${shortenEthereumAddress(ethereumAddress)}`
-      : `${withHyphen ? "— " : ""}${ethereumAddress}`;
+      ? `${withHyphen === true ? "— " : ""}${shortenEthereumAddress(ethereumAddress)}`
+      : `${withHyphen === true ? "— " : ""}${ethereumAddress}`;
   }
 
   if (queryUserProfileLens?.status === "loading")

--- a/packages/react-app-revamp/components/_pages/ListProposalVotes/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposalVotes/index.tsx
@@ -132,6 +132,7 @@ export const ListProposalVotes = (props: ListProposalVotesProps) => {
                       >
                         Click to view this address on Debank
                       </a>
+                      
                       <EtheuremAddress
                         withHyphen={false}
                         ethereumAddress={address}

--- a/packages/react-app-revamp/components/_pages/ListProposalVotes/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposalVotes/index.tsx
@@ -5,6 +5,7 @@ import { useStore as useStoreProposalVotes } from "@hooks/useProposalVotes/store
 import { useStore as useStoreContest } from "@hooks/useContest/store";
 import shallow from "zustand/shallow";
 import { useAccount } from "wagmi";
+import EtheuremAddress from "@components/EtheuremAddress";
 
 interface ListProposalVotesProps {
   id: number | string;
@@ -131,7 +132,12 @@ export const ListProposalVotes = (props: ListProposalVotesProps) => {
                       >
                         Click to view this address on Debank
                       </a>
-                      {votesPerAddress[address].displayAddress}:
+                      <EtheuremAddress
+                        withHyphen={false}
+                        ethereumAddress={address}
+                        shortenOnFallback={true}
+                        displayLensProfile={true}
+                      />
                     </td>
                     <td className="p-2 font-bold">
                       {new Intl.NumberFormat().format(parseFloat(votesPerAddress[address].votes.toFixed(2)))}

--- a/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
@@ -259,7 +259,7 @@ export const ListProposals = () => {
                         </span>
                       )}
                       <ProposalContent
-                        author={listProposalsData[id].author}
+                        author={listProposalsData[id].authorEthereumAddress}
                         content={
                           listProposalsData[id].isContentImage
                             ? listProposalsData[id].content

--- a/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
@@ -55,6 +55,7 @@ export const ProposalContent = (props: ProposalContentProps) => {
       </blockquote>
       {!isProposalDeleted(content) && (
         <figcaption className="pt-5 font-mono overflow-hidden text-neutral-12 text-ellipsis whitespace-nowrap">
+          {/*@ts-ignore*/}
           <EtheuremAddress
             ethereumAddress={author}
             displayLensProfile={true}

--- a/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ProposalContent/index.tsx
@@ -5,6 +5,7 @@ import { Interweave } from "interweave";
 import { UrlMatcher } from "interweave-autolink";
 import styles from "./styles.module.css";
 import isProposalDeleted from "@helpers/isProposalDeleted";
+import EtheuremAddress from "@components/EtheuremAddress";
 interface ProposalContentProps {
   content: string;
   author: string;
@@ -54,7 +55,12 @@ export const ProposalContent = (props: ProposalContentProps) => {
       </blockquote>
       {!isProposalDeleted(content) && (
         <figcaption className="pt-5 font-mono overflow-hidden text-neutral-12 text-ellipsis whitespace-nowrap">
-          — {author}
+          <EtheuremAddress
+            ethereumAddress={author}
+            displayLensProfile={true}
+            shortenOnFallback={false}
+            withHyphen={true}
+          />
         </figcaption>
       )}
     </>

--- a/packages/react-app-revamp/config/links/index.tsx
+++ b/packages/react-app-revamp/config/links/index.tsx
@@ -9,7 +9,7 @@ const LINK_BUG_REPORT =
   "https://github.com/JokeDAO/JokeDaoV2Dev/issues/new?assignees=&labels=bug&template=bug_report.md&title=%5BBUG%5D";
 const LINK_REQUEST_FEATURE =
   "https://github.com/JokeDAO/JokeDaoV2Dev/issues/new?assignees=&labels=enhancement%2C+question%2C+ux&template=feature_request.md&title=%5BFEAT.%5D";
-const LINK_FAQ = "https://joke.mirror.xyz/4wiTHmaeVgwAG_W2gK1XKeIE2NpKYJxrxKoqNdzR_co"
+const LINK_FAQ = "https://joke.mirror.xyz/4wiTHmaeVgwAG_W2gK1XKeIE2NpKYJxrxKoqNdzR_co";
 
 export const FOOTER_LINKS = [
   {

--- a/packages/react-app-revamp/config/urql/index.ts
+++ b/packages/react-app-revamp/config/urql/index.ts
@@ -1,0 +1,9 @@
+import { createClient } from "urql";
+
+const API_URL = (process.env.NEXT_PUBLIC_LENS_API_URL as string) ?? "https://api.lens.dev";
+
+export const client = new createClient({
+  url: API_URL,
+});
+
+export default client;

--- a/packages/react-app-revamp/config/urql/index.ts
+++ b/packages/react-app-revamp/config/urql/index.ts
@@ -2,6 +2,7 @@ import { createClient } from "urql";
 
 const API_URL = (process.env.NEXT_PUBLIC_LENS_API_URL as string) ?? "https://api.lens.dev";
 
+//@ts-ignore
 export const client = new createClient({
   url: API_URL,
 });

--- a/packages/react-app-revamp/config/wagmi/index.ts
+++ b/packages/react-app-revamp/config/wagmi/index.ts
@@ -8,17 +8,9 @@ import { connectorsForWallets, getDefaultWallets, wallet } from "@rainbow-me/rai
 const infuraId = process.env.NEXT_PUBLIC_INFURA_ID;
 const alchemyId = process.env.NEXT_PUBLIC_ALCHEMY_KEY;
 
-const testnetChains = [
-  chain.polygonMumbai,
-  chain.goerli,
-];
+const testnetChains = [chain.polygonMumbai, chain.goerli];
 
-const defaultChains = [
-  chain.polygon,
-  chain.arbitrum,
-  chain.mainnet,
-  chain.optimism,
-];
+const defaultChains = [chain.polygon, chain.arbitrum, chain.mainnet, chain.optimism];
 const appChains = [...defaultChains, ...testnetChains];
 const providers =
   process.env.NODE_ENV === "development"

--- a/packages/react-app-revamp/graphql/common.graphql
+++ b/packages/react-app-revamp/graphql/common.graphql
@@ -1,0 +1,358 @@
+fragment MediaFields on Media {
+  url
+  width
+  height
+  mimeType
+}
+
+fragment ProfileFields on Profile {
+  id
+  name
+  bio
+  attributes {
+    displayType
+    traitType
+    key
+    value
+  }
+  isFollowedByMe
+  isFollowing(who: null)
+  followNftAddress
+  metadata
+  isDefault
+  handle
+  picture {
+    ... on NftImage {
+      contractAddress
+      tokenId
+      uri
+      verified
+    }
+    ... on MediaSet {
+      original {
+        ...MediaFields
+      }
+      small {
+        ...MediaFields
+      }
+      medium {
+        ...MediaFields
+      }
+    }
+  }
+  coverPicture {
+    ... on NftImage {
+      contractAddress
+      tokenId
+      uri
+      verified
+    }
+    ... on MediaSet {
+      original {
+        ...MediaFields
+      }
+      small {
+        ...MediaFields
+      }
+      medium {
+        ...MediaFields
+      }
+    }
+  }
+  ownedBy
+  dispatcher {
+    address
+  }
+  stats {
+    totalFollowers
+    totalFollowing
+    totalPosts
+    totalComments
+    totalMirrors
+    totalPublications
+    totalCollects
+  }
+  followModule {
+    ... on FeeFollowModuleSettings {
+      type
+      amount {
+        asset {
+          name
+          symbol
+          decimals
+          address
+        }
+        value
+      }
+      recipient
+    }
+    ... on ProfileFollowModuleSettings {
+      type
+    }
+    ... on RevertFollowModuleSettings {
+      type
+    }
+  }
+}
+
+fragment PublicationStatsFields on PublicationStats {
+  totalAmountOfMirrors
+  totalAmountOfCollects
+  totalAmountOfComments
+}
+
+fragment MetadataOutputFields on MetadataOutput {
+  name
+  description
+  content
+  media {
+    original {
+      ...MediaFields
+    }
+    small {
+      ...MediaFields
+    }
+    medium {
+      ...MediaFields
+    }
+  }
+  attributes {
+    displayType
+    traitType
+    value
+  }
+}
+
+fragment Erc20Fields on Erc20 {
+  name
+  symbol
+  decimals
+  address
+}
+
+fragment CollectModuleFields on CollectModule {
+  __typename
+  ... on FreeCollectModuleSettings {
+    type
+    followerOnly
+    contractAddress
+  }
+  ... on FeeCollectModuleSettings {
+    type
+    amount {
+      asset {
+        ...Erc20Fields
+      }
+      value
+    }
+    recipient
+    referralFee
+  }
+  ... on LimitedFeeCollectModuleSettings {
+    type
+    collectLimit
+    amount {
+      asset {
+        ...Erc20Fields
+      }
+      value
+    }
+    recipient
+    referralFee
+  }
+  ... on LimitedTimedFeeCollectModuleSettings {
+    type
+    collectLimit
+    amount {
+      asset {
+        ...Erc20Fields
+      }
+      value
+    }
+    recipient
+    referralFee
+    endTimestamp
+  }
+  ... on RevertCollectModuleSettings {
+    type
+  }
+  ... on TimedFeeCollectModuleSettings {
+    type
+    amount {
+      asset {
+        ...Erc20Fields
+      }
+      value
+    }
+    recipient
+    referralFee
+    endTimestamp
+  }
+}
+
+fragment PostFields on Post {
+  id
+  profile {
+    ...ProfileFields
+  }
+  stats {
+    ...PublicationStatsFields
+  }
+  metadata {
+    ...MetadataOutputFields
+  }
+  createdAt
+  collectModule {
+    ...CollectModuleFields
+  }
+  referenceModule {
+    ... on FollowOnlyReferenceModuleSettings {
+      type
+    }
+  }
+  appId
+  hidden
+  reaction(request: null)
+  mirrors(by: null)
+  hasCollectedByMe
+}
+
+fragment MirrorBaseFields on Mirror {
+  id
+  profile {
+    ...ProfileFields
+  }
+  stats {
+    ...PublicationStatsFields
+  }
+  metadata {
+    ...MetadataOutputFields
+  }
+  createdAt
+  collectModule {
+    ...CollectModuleFields
+  }
+  referenceModule {
+    ... on FollowOnlyReferenceModuleSettings {
+      type
+    }
+  }
+  appId
+  hidden
+  reaction(request: null)
+  hasCollectedByMe
+}
+
+fragment MirrorFields on Mirror {
+  ...MirrorBaseFields
+  mirrorOf {
+    ... on Post {
+      ...PostFields
+    }
+    ... on Comment {
+      ...CommentFields
+    }
+  }
+}
+
+fragment CommentBaseFields on Comment {
+  id
+  profile {
+    ...ProfileFields
+  }
+  stats {
+    ...PublicationStatsFields
+  }
+  metadata {
+    ...MetadataOutputFields
+  }
+  createdAt
+  collectModule {
+    ...CollectModuleFields
+  }
+  referenceModule {
+    ... on FollowOnlyReferenceModuleSettings {
+      type
+    }
+  }
+  appId
+  hidden
+  reaction(request: null)
+  mirrors(by: null)
+  hasCollectedByMe
+}
+
+fragment CommentFields on Comment {
+  ...CommentBaseFields
+  mainPost {
+    ... on Post {
+      ...PostFields
+    }
+    ... on Mirror {
+      ...MirrorBaseFields
+      mirrorOf {
+        ... on Post {
+          ...PostFields
+        }
+        ... on Comment {
+          ...CommentMirrorOfFields
+        }
+      }
+    }
+  }
+}
+
+fragment CommentMirrorOfFields on Comment {
+  ...CommentBaseFields
+  mainPost {
+    ... on Post {
+      ...PostFields
+    }
+    ... on Mirror {
+      ...MirrorBaseFields
+    }
+  }
+}
+
+fragment TxReceiptFields on TransactionReceipt {
+  to
+  from
+  contractAddress
+  transactionIndex
+  root
+  gasUsed
+  logsBloom
+  blockHash
+  transactionHash
+  blockNumber
+  confirmations
+  cumulativeGasUsed
+  effectiveGasPrice
+  byzantium
+  type
+  status
+  logs {
+    blockNumber
+    blockHash
+    transactionIndex
+    removed
+    address
+    data
+    topics
+    transactionHash
+    logIndex
+  }
+}
+
+fragment WalletFields on Wallet {
+  address
+  defaultProfile {
+    ...ProfileFields
+  }
+}
+
+fragment CommonPaginatedResultFields on PaginatedResultInfo {
+  prev
+  next
+  totalCount
+}

--- a/packages/react-app-revamp/graphql/generated.ts
+++ b/packages/react-app-revamp/graphql/generated.ts
@@ -1,0 +1,9920 @@
+import { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  BlockchainData: any;
+  BroadcastId: any;
+  ChainId: any;
+  CollectModuleData: any;
+  ContractAddress: any;
+  CreateHandle: any;
+  Cursor: any;
+  DateTime: any;
+  Ens: any;
+  EthereumAddress: any;
+  FollowModuleData: any;
+  Handle: any;
+  HandleClaimIdScalar: any;
+  InternalPublicationId: any;
+  Jwt: any;
+  LimitScalar: any;
+  Locale: any;
+  Markdown: any;
+  MimeType: any;
+  NftOwnershipId: any;
+  Nonce: any;
+  NotificationId: any;
+  ProfileId: any;
+  ProxyActionId: any;
+  PublicationId: any;
+  PublicationTag: any;
+  PublicationUrl: any;
+  ReactionId: any;
+  ReferenceModuleData: any;
+  Search: any;
+  Signature: any;
+  Sources: any;
+  TimestampScalar: any;
+  TxHash: any;
+  TxId: any;
+  UnixTimestamp: any;
+  Url: any;
+  Void: any;
+};
+
+export type AchRequest = {
+  ethereumAddress: Scalars["EthereumAddress"];
+  freeTextHandle?: InputMaybe<Scalars["Boolean"]>;
+  handle?: InputMaybe<Scalars["CreateHandle"]>;
+  overrideAlreadyClaimed: Scalars["Boolean"];
+  overrideTradeMark: Scalars["Boolean"];
+  secret: Scalars["String"];
+};
+
+export type AllPublicationsTagsRequest = {
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+  sort: TagSortCriteria;
+  /** The App Id */
+  source?: InputMaybe<Scalars["Sources"]>;
+};
+
+export type ApprovedAllowanceAmount = {
+  __typename?: "ApprovedAllowanceAmount";
+  allowance: Scalars["String"];
+  contractAddress: Scalars["ContractAddress"];
+  currency: Scalars["ContractAddress"];
+  module: Scalars["String"];
+};
+
+export type ApprovedModuleAllowanceAmountRequest = {
+  collectModules?: InputMaybe<Array<CollectModules>>;
+  /** The contract addresses for the module approved currencies you want to find information on about the user */
+  currencies: Array<Scalars["ContractAddress"]>;
+  followModules?: InputMaybe<Array<FollowModules>>;
+  referenceModules?: InputMaybe<Array<ReferenceModules>>;
+  unknownCollectModules?: InputMaybe<Array<Scalars["ContractAddress"]>>;
+  unknownFollowModules?: InputMaybe<Array<Scalars["ContractAddress"]>>;
+  unknownReferenceModules?: InputMaybe<Array<Scalars["ContractAddress"]>>;
+};
+
+/** The Profile */
+export type Attribute = {
+  __typename?: "Attribute";
+  /** The display type */
+  displayType?: Maybe<Scalars["String"]>;
+  /** identifier of this attribute, we will update by this id  */
+  key: Scalars["String"];
+  /** The trait type - can be anything its the name it will render so include spaces */
+  traitType?: Maybe<Scalars["String"]>;
+  /** Value attribute */
+  value: Scalars["String"];
+};
+
+/** The auth challenge result */
+export type AuthChallengeResult = {
+  __typename?: "AuthChallengeResult";
+  /** The text to sign */
+  text: Scalars["String"];
+};
+
+/** The authentication result */
+export type AuthenticationResult = {
+  __typename?: "AuthenticationResult";
+  /** The access token */
+  accessToken: Scalars["Jwt"];
+  /** The refresh token */
+  refreshToken: Scalars["Jwt"];
+};
+
+export type BroadcastRequest = {
+  id: Scalars["BroadcastId"];
+  signature: Scalars["Signature"];
+};
+
+export type BurnProfileRequest = {
+  profileId: Scalars["ProfileId"];
+};
+
+export type CanCommentResponse = {
+  __typename?: "CanCommentResponse";
+  result: Scalars["Boolean"];
+};
+
+export type CanMirrorResponse = {
+  __typename?: "CanMirrorResponse";
+  result: Scalars["Boolean"];
+};
+
+/** The challenge request */
+export type ChallengeRequest = {
+  /** The ethereum address you want to login with */
+  address: Scalars["EthereumAddress"];
+};
+
+export type ClaimHandleRequest = {
+  /** The follow module */
+  followModule?: InputMaybe<FollowModuleParams>;
+  freeTextHandle?: InputMaybe<Scalars["CreateHandle"]>;
+  id?: InputMaybe<Scalars["HandleClaimIdScalar"]>;
+};
+
+/** The claim status */
+export enum ClaimStatus {
+  AlreadyClaimed = "ALREADY_CLAIMED",
+  ClaimFailed = "CLAIM_FAILED",
+  NotClaimed = "NOT_CLAIMED",
+}
+
+export type ClaimableHandles = {
+  __typename?: "ClaimableHandles";
+  canClaimFreeTextHandle: Scalars["Boolean"];
+  reservedHandles: Array<ReservedClaimableHandle>;
+};
+
+export type CollectModule =
+  | FeeCollectModuleSettings
+  | FreeCollectModuleSettings
+  | LimitedFeeCollectModuleSettings
+  | LimitedTimedFeeCollectModuleSettings
+  | RevertCollectModuleSettings
+  | TimedFeeCollectModuleSettings
+  | UnknownCollectModuleSettings;
+
+export type CollectModuleParams = {
+  /** The collect fee collect module */
+  feeCollectModule?: InputMaybe<FeeCollectModuleParams>;
+  /** The collect empty collect module */
+  freeCollectModule?: InputMaybe<FreeCollectModuleParams>;
+  /** The collect limited fee collect module */
+  limitedFeeCollectModule?: InputMaybe<LimitedFeeCollectModuleParams>;
+  /** The collect limited timed fee collect module */
+  limitedTimedFeeCollectModule?: InputMaybe<LimitedTimedFeeCollectModuleParams>;
+  /** The collect revert collect module */
+  revertCollectModule?: InputMaybe<Scalars["Boolean"]>;
+  /** The collect timed fee collect module */
+  timedFeeCollectModule?: InputMaybe<TimedFeeCollectModuleParams>;
+  /** A unknown collect module */
+  unknownCollectModule?: InputMaybe<UnknownCollectModuleParams>;
+};
+
+/** The collect module types */
+export enum CollectModules {
+  FeeCollectModule = "FeeCollectModule",
+  FreeCollectModule = "FreeCollectModule",
+  LimitedFeeCollectModule = "LimitedFeeCollectModule",
+  LimitedTimedFeeCollectModule = "LimitedTimedFeeCollectModule",
+  RevertCollectModule = "RevertCollectModule",
+  TimedFeeCollectModule = "TimedFeeCollectModule",
+  UnknownCollectModule = "UnknownCollectModule",
+}
+
+export type CollectProxyAction = {
+  freeCollect?: InputMaybe<FreeCollectProxyAction>;
+};
+
+export type CollectedEvent = {
+  __typename?: "CollectedEvent";
+  profile: Profile;
+  timestamp: Scalars["DateTime"];
+};
+
+/** The social comment */
+export type Comment = {
+  __typename?: "Comment";
+  /** ID of the source */
+  appId?: Maybe<Scalars["Sources"]>;
+  canComment: CanCommentResponse;
+  canMirror: CanMirrorResponse;
+  /** The collect module */
+  collectModule: CollectModule;
+  /** The contract address for the collect nft.. if its null it means nobody collected yet as it lazy deployed */
+  collectNftAddress?: Maybe<Scalars["ContractAddress"]>;
+  /** Who collected it, this is used for timeline results and like this for better caching for the client */
+  collectedBy?: Maybe<Wallet>;
+  /** Which comment this points to if its null the pointer too deep so do another query to find it out */
+  commentOn?: Maybe<Publication>;
+  /** The date the post was created on */
+  createdAt: Scalars["DateTime"];
+  /** This will bring back the first comment of a comment and only be defined if using `publication` query and `commentOf` */
+  firstComment?: Maybe<Comment>;
+  hasCollectedByMe: Scalars["Boolean"];
+  /** If the publication has been hidden if it has then the content and media is not available */
+  hidden: Scalars["Boolean"];
+  /** The internal publication id */
+  id: Scalars["InternalPublicationId"];
+  /** The top level post/mirror this comment lives on */
+  mainPost: MainPostReference;
+  /** The metadata for the post */
+  metadata: MetadataOutput;
+  mirrors: Array<Scalars["InternalPublicationId"]>;
+  /** The on chain content uri could be `ipfs://` or `https` */
+  onChainContentURI: Scalars["String"];
+  /** The profile ref */
+  profile: Profile;
+  reaction?: Maybe<ReactionTypes>;
+  /** The reference module */
+  referenceModule?: Maybe<ReferenceModule>;
+  /** The publication stats */
+  stats: PublicationStats;
+};
+
+/** The social comment */
+export type CommentCanCommentArgs = {
+  profileId?: InputMaybe<Scalars["ProfileId"]>;
+};
+
+/** The social comment */
+export type CommentCanMirrorArgs = {
+  profileId?: InputMaybe<Scalars["ProfileId"]>;
+};
+
+/** The social comment */
+export type CommentMirrorsArgs = {
+  by?: InputMaybe<Scalars["ProfileId"]>;
+};
+
+/** The social comment */
+export type CommentReactionArgs = {
+  request?: InputMaybe<ReactionFieldResolverRequest>;
+};
+
+/** The create burn eip 712 typed data */
+export type CreateBurnEip712TypedData = {
+  __typename?: "CreateBurnEIP712TypedData";
+  /** The typed data domain */
+  domain: Eip712TypedDataDomain;
+  /** The types */
+  types: CreateBurnEip712TypedDataTypes;
+  /** The values */
+  value: CreateBurnEip712TypedDataValue;
+};
+
+/** The create burn eip 712 typed data types */
+export type CreateBurnEip712TypedDataTypes = {
+  __typename?: "CreateBurnEIP712TypedDataTypes";
+  BurnWithSig: Array<Eip712TypedDataField>;
+};
+
+/** The create burn eip 712 typed data value */
+export type CreateBurnEip712TypedDataValue = {
+  __typename?: "CreateBurnEIP712TypedDataValue";
+  deadline: Scalars["UnixTimestamp"];
+  nonce: Scalars["Nonce"];
+  tokenId: Scalars["String"];
+};
+
+/** The broadcast item */
+export type CreateBurnProfileBroadcastItemResult = {
+  __typename?: "CreateBurnProfileBroadcastItemResult";
+  /** The date the broadcast item expiries */
+  expiresAt: Scalars["DateTime"];
+  /** This broadcast item ID */
+  id: Scalars["BroadcastId"];
+  /** The typed data */
+  typedData: CreateBurnEip712TypedData;
+};
+
+/** The broadcast item */
+export type CreateCollectBroadcastItemResult = {
+  __typename?: "CreateCollectBroadcastItemResult";
+  /** The date the broadcast item expiries */
+  expiresAt: Scalars["DateTime"];
+  /** This broadcast item ID */
+  id: Scalars["BroadcastId"];
+  /** The typed data */
+  typedData: CreateCollectEip712TypedData;
+};
+
+/** The collect eip 712 typed data */
+export type CreateCollectEip712TypedData = {
+  __typename?: "CreateCollectEIP712TypedData";
+  /** The typed data domain */
+  domain: Eip712TypedDataDomain;
+  /** The types */
+  types: CreateCollectEip712TypedDataTypes;
+  /** The values */
+  value: CreateCollectEip712TypedDataValue;
+};
+
+/** The collect eip 712 typed data types */
+export type CreateCollectEip712TypedDataTypes = {
+  __typename?: "CreateCollectEIP712TypedDataTypes";
+  CollectWithSig: Array<Eip712TypedDataField>;
+};
+
+/** The collect eip 712 typed data value */
+export type CreateCollectEip712TypedDataValue = {
+  __typename?: "CreateCollectEIP712TypedDataValue";
+  data: Scalars["BlockchainData"];
+  deadline: Scalars["UnixTimestamp"];
+  nonce: Scalars["Nonce"];
+  profileId: Scalars["ProfileId"];
+  pubId: Scalars["PublicationId"];
+};
+
+export type CreateCollectRequest = {
+  publicationId: Scalars["InternalPublicationId"];
+  /** The encoded data to collect with if using an unknown module */
+  unknownModuleData?: InputMaybe<Scalars["BlockchainData"]>;
+};
+
+/** The broadcast item */
+export type CreateCommentBroadcastItemResult = {
+  __typename?: "CreateCommentBroadcastItemResult";
+  /** The date the broadcast item expiries */
+  expiresAt: Scalars["DateTime"];
+  /** This broadcast item ID */
+  id: Scalars["BroadcastId"];
+  /** The typed data */
+  typedData: CreateCommentEip712TypedData;
+};
+
+/** The create comment eip 712 typed data */
+export type CreateCommentEip712TypedData = {
+  __typename?: "CreateCommentEIP712TypedData";
+  /** The typed data domain */
+  domain: Eip712TypedDataDomain;
+  /** The types */
+  types: CreateCommentEip712TypedDataTypes;
+  /** The values */
+  value: CreateCommentEip712TypedDataValue;
+};
+
+/** The create comment eip 712 typed data types */
+export type CreateCommentEip712TypedDataTypes = {
+  __typename?: "CreateCommentEIP712TypedDataTypes";
+  CommentWithSig: Array<Eip712TypedDataField>;
+};
+
+/** The create comment eip 712 typed data value */
+export type CreateCommentEip712TypedDataValue = {
+  __typename?: "CreateCommentEIP712TypedDataValue";
+  collectModule: Scalars["ContractAddress"];
+  collectModuleInitData: Scalars["CollectModuleData"];
+  contentURI: Scalars["PublicationUrl"];
+  deadline: Scalars["UnixTimestamp"];
+  nonce: Scalars["Nonce"];
+  profileId: Scalars["ProfileId"];
+  profileIdPointed: Scalars["ProfileId"];
+  pubIdPointed: Scalars["PublicationId"];
+  referenceModule: Scalars["ContractAddress"];
+  referenceModuleData: Scalars["ReferenceModuleData"];
+  referenceModuleInitData: Scalars["ReferenceModuleData"];
+};
+
+/** The broadcast item */
+export type CreateFollowBroadcastItemResult = {
+  __typename?: "CreateFollowBroadcastItemResult";
+  /** The date the broadcast item expiries */
+  expiresAt: Scalars["DateTime"];
+  /** This broadcast item ID */
+  id: Scalars["BroadcastId"];
+  /** The typed data */
+  typedData: CreateFollowEip712TypedData;
+};
+
+/** The create follow eip 712 typed data */
+export type CreateFollowEip712TypedData = {
+  __typename?: "CreateFollowEIP712TypedData";
+  /** The typed data domain */
+  domain: Eip712TypedDataDomain;
+  /** The types */
+  types: CreateFollowEip712TypedDataTypes;
+  /** The values */
+  value: CreateFollowEip712TypedDataValue;
+};
+
+/** The create follow eip 712 typed data types */
+export type CreateFollowEip712TypedDataTypes = {
+  __typename?: "CreateFollowEIP712TypedDataTypes";
+  FollowWithSig: Array<Eip712TypedDataField>;
+};
+
+/** The create follow eip 712 typed data value */
+export type CreateFollowEip712TypedDataValue = {
+  __typename?: "CreateFollowEIP712TypedDataValue";
+  datas: Array<Scalars["BlockchainData"]>;
+  deadline: Scalars["UnixTimestamp"];
+  nonce: Scalars["Nonce"];
+  profileIds: Array<Scalars["ProfileId"]>;
+};
+
+/** The broadcast item */
+export type CreateMirrorBroadcastItemResult = {
+  __typename?: "CreateMirrorBroadcastItemResult";
+  /** The date the broadcast item expiries */
+  expiresAt: Scalars["DateTime"];
+  /** This broadcast item ID */
+  id: Scalars["BroadcastId"];
+  /** The typed data */
+  typedData: CreateMirrorEip712TypedData;
+};
+
+/** The mirror eip 712 typed data */
+export type CreateMirrorEip712TypedData = {
+  __typename?: "CreateMirrorEIP712TypedData";
+  /** The typed data domain */
+  domain: Eip712TypedDataDomain;
+  /** The types */
+  types: CreateMirrorEip712TypedDataTypes;
+  /** The values */
+  value: CreateMirrorEip712TypedDataValue;
+};
+
+/** The mirror eip 712 typed data types */
+export type CreateMirrorEip712TypedDataTypes = {
+  __typename?: "CreateMirrorEIP712TypedDataTypes";
+  MirrorWithSig: Array<Eip712TypedDataField>;
+};
+
+/** The mirror eip 712 typed data value */
+export type CreateMirrorEip712TypedDataValue = {
+  __typename?: "CreateMirrorEIP712TypedDataValue";
+  deadline: Scalars["UnixTimestamp"];
+  nonce: Scalars["Nonce"];
+  profileId: Scalars["ProfileId"];
+  profileIdPointed: Scalars["ProfileId"];
+  pubIdPointed: Scalars["PublicationId"];
+  referenceModule: Scalars["ContractAddress"];
+  referenceModuleData: Scalars["ReferenceModuleData"];
+  referenceModuleInitData: Scalars["ReferenceModuleData"];
+};
+
+export type CreateMirrorRequest = {
+  /** Profile id */
+  profileId: Scalars["ProfileId"];
+  /** Publication id of what you want to mirror on remember if this is a comment it will be that as the id */
+  publicationId: Scalars["InternalPublicationId"];
+  /** The reference module info */
+  referenceModule?: InputMaybe<ReferenceModuleParams>;
+};
+
+/** The broadcast item */
+export type CreatePostBroadcastItemResult = {
+  __typename?: "CreatePostBroadcastItemResult";
+  /** The date the broadcast item expiries */
+  expiresAt: Scalars["DateTime"];
+  /** This broadcast item ID */
+  id: Scalars["BroadcastId"];
+  /** The typed data */
+  typedData: CreatePostEip712TypedData;
+};
+
+/** The create post eip 712 typed data */
+export type CreatePostEip712TypedData = {
+  __typename?: "CreatePostEIP712TypedData";
+  /** The typed data domain */
+  domain: Eip712TypedDataDomain;
+  /** The types */
+  types: CreatePostEip712TypedDataTypes;
+  /** The values */
+  value: CreatePostEip712TypedDataValue;
+};
+
+/** The create post eip 712 typed data types */
+export type CreatePostEip712TypedDataTypes = {
+  __typename?: "CreatePostEIP712TypedDataTypes";
+  PostWithSig: Array<Eip712TypedDataField>;
+};
+
+/** The create post eip 712 typed data value */
+export type CreatePostEip712TypedDataValue = {
+  __typename?: "CreatePostEIP712TypedDataValue";
+  collectModule: Scalars["ContractAddress"];
+  collectModuleInitData: Scalars["CollectModuleData"];
+  contentURI: Scalars["PublicationUrl"];
+  deadline: Scalars["UnixTimestamp"];
+  nonce: Scalars["Nonce"];
+  profileId: Scalars["ProfileId"];
+  referenceModule: Scalars["ContractAddress"];
+  referenceModuleInitData: Scalars["ReferenceModuleData"];
+};
+
+export type CreatePublicCommentRequest = {
+  /** The collect module */
+  collectModule: CollectModuleParams;
+  /** The metadata uploaded somewhere passing in the url to reach it */
+  contentURI: Scalars["Url"];
+  /** Profile id */
+  profileId: Scalars["ProfileId"];
+  /** Publication id of what your comments on remember if this is a comment you commented on it will be that as the id */
+  publicationId: Scalars["InternalPublicationId"];
+  /** The reference module */
+  referenceModule?: InputMaybe<ReferenceModuleParams>;
+};
+
+export type CreatePublicPostRequest = {
+  /** The collect module */
+  collectModule: CollectModuleParams;
+  /** The metadata uploaded somewhere passing in the url to reach it */
+  contentURI: Scalars["Url"];
+  /** Profile id */
+  profileId: Scalars["ProfileId"];
+  /** The reference module */
+  referenceModule?: InputMaybe<ReferenceModuleParams>;
+};
+
+export type CreatePublicSetProfileMetadataUriRequest = {
+  /** The metadata uploaded somewhere passing in the url to reach it */
+  metadata: Scalars["Url"];
+  /** Profile id */
+  profileId: Scalars["ProfileId"];
+};
+
+export type CreateSetDefaultProfileRequest = {
+  /** Profile id */
+  profileId: Scalars["ProfileId"];
+};
+
+/** The broadcast item */
+export type CreateSetDispatcherBroadcastItemResult = {
+  __typename?: "CreateSetDispatcherBroadcastItemResult";
+  /** The date the broadcast item expiries */
+  expiresAt: Scalars["DateTime"];
+  /** This broadcast item ID */
+  id: Scalars["BroadcastId"];
+  /** The typed data */
+  typedData: CreateSetDispatcherEip712TypedData;
+};
+
+/** The set dispatcher eip 712 typed data */
+export type CreateSetDispatcherEip712TypedData = {
+  __typename?: "CreateSetDispatcherEIP712TypedData";
+  /** The typed data domain */
+  domain: Eip712TypedDataDomain;
+  /** The types */
+  types: CreateSetDispatcherEip712TypedDataTypes;
+  /** The values */
+  value: CreateSetDispatcherEip712TypedDataValue;
+};
+
+/** The set dispatcher eip 712 typed data types */
+export type CreateSetDispatcherEip712TypedDataTypes = {
+  __typename?: "CreateSetDispatcherEIP712TypedDataTypes";
+  SetDispatcherWithSig: Array<Eip712TypedDataField>;
+};
+
+/** The set dispatcher eip 712 typed data value */
+export type CreateSetDispatcherEip712TypedDataValue = {
+  __typename?: "CreateSetDispatcherEIP712TypedDataValue";
+  deadline: Scalars["UnixTimestamp"];
+  dispatcher: Scalars["EthereumAddress"];
+  nonce: Scalars["Nonce"];
+  profileId: Scalars["ProfileId"];
+};
+
+/** The broadcast item */
+export type CreateSetFollowModuleBroadcastItemResult = {
+  __typename?: "CreateSetFollowModuleBroadcastItemResult";
+  /** The date the broadcast item expiries */
+  expiresAt: Scalars["DateTime"];
+  /** This broadcast item ID */
+  id: Scalars["BroadcastId"];
+  /** The typed data */
+  typedData: CreateSetFollowModuleEip712TypedData;
+};
+
+/** The set follow module eip 712 typed data */
+export type CreateSetFollowModuleEip712TypedData = {
+  __typename?: "CreateSetFollowModuleEIP712TypedData";
+  /** The typed data domain */
+  domain: Eip712TypedDataDomain;
+  /** The types */
+  types: CreateSetFollowModuleEip712TypedDataTypes;
+  /** The values */
+  value: CreateSetFollowModuleEip712TypedDataValue;
+};
+
+/** The set follow module eip 712 typed data types */
+export type CreateSetFollowModuleEip712TypedDataTypes = {
+  __typename?: "CreateSetFollowModuleEIP712TypedDataTypes";
+  SetFollowModuleWithSig: Array<Eip712TypedDataField>;
+};
+
+/** The set follow module eip 712 typed data value */
+export type CreateSetFollowModuleEip712TypedDataValue = {
+  __typename?: "CreateSetFollowModuleEIP712TypedDataValue";
+  deadline: Scalars["UnixTimestamp"];
+  followModule: Scalars["ContractAddress"];
+  followModuleInitData: Scalars["FollowModuleData"];
+  nonce: Scalars["Nonce"];
+  profileId: Scalars["ProfileId"];
+};
+
+export type CreateSetFollowModuleRequest = {
+  /** The follow module info */
+  followModule: FollowModuleParams;
+  profileId: Scalars["ProfileId"];
+};
+
+/** The broadcast item */
+export type CreateSetFollowNftUriBroadcastItemResult = {
+  __typename?: "CreateSetFollowNFTUriBroadcastItemResult";
+  /** The date the broadcast item expiries */
+  expiresAt: Scalars["DateTime"];
+  /** This broadcast item ID */
+  id: Scalars["BroadcastId"];
+  /** The typed data */
+  typedData: CreateSetFollowNftUriEip712TypedData;
+};
+
+/** The set follow nft uri eip 712 typed data */
+export type CreateSetFollowNftUriEip712TypedData = {
+  __typename?: "CreateSetFollowNFTUriEIP712TypedData";
+  /** The typed data domain */
+  domain: Eip712TypedDataDomain;
+  /** The types */
+  types: CreateSetFollowNftUriEip712TypedDataTypes;
+  /** The values */
+  value: CreateSetFollowNftUriEip712TypedDataValue;
+};
+
+/** The set follow nft uri eip 712 typed data types */
+export type CreateSetFollowNftUriEip712TypedDataTypes = {
+  __typename?: "CreateSetFollowNFTUriEIP712TypedDataTypes";
+  SetFollowNFTURIWithSig: Array<Eip712TypedDataField>;
+};
+
+/** The set follow nft uri eip 712 typed data value */
+export type CreateSetFollowNftUriEip712TypedDataValue = {
+  __typename?: "CreateSetFollowNFTUriEIP712TypedDataValue";
+  deadline: Scalars["UnixTimestamp"];
+  followNFTURI: Scalars["Url"];
+  nonce: Scalars["Nonce"];
+  profileId: Scalars["ProfileId"];
+};
+
+export type CreateSetFollowNftUriRequest = {
+  /** The follow NFT URI is the NFT metadata your followers will mint when they follow you. This can be updated at all times. If you do not pass in anything it will create a super cool changing NFT which will show the last publication of your profile as the NFT which looks awesome! This means people do not have to worry about writing this logic but still have the ability to customise it for their followers */
+  followNFTURI?: InputMaybe<Scalars["Url"]>;
+  profileId: Scalars["ProfileId"];
+};
+
+/** The broadcast item */
+export type CreateSetProfileImageUriBroadcastItemResult = {
+  __typename?: "CreateSetProfileImageUriBroadcastItemResult";
+  /** The date the broadcast item expiries */
+  expiresAt: Scalars["DateTime"];
+  /** This broadcast item ID */
+  id: Scalars["BroadcastId"];
+  /** The typed data */
+  typedData: CreateSetProfileImageUriEip712TypedData;
+};
+
+/** The set profile uri eip 712 typed data */
+export type CreateSetProfileImageUriEip712TypedData = {
+  __typename?: "CreateSetProfileImageUriEIP712TypedData";
+  /** The typed data domain */
+  domain: Eip712TypedDataDomain;
+  /** The types */
+  types: CreateSetProfileImageUriEip712TypedDataTypes;
+  /** The values */
+  value: CreateSetProfileImageUriEip712TypedDataValue;
+};
+
+/** The set profile image uri eip 712 typed data types */
+export type CreateSetProfileImageUriEip712TypedDataTypes = {
+  __typename?: "CreateSetProfileImageUriEIP712TypedDataTypes";
+  SetProfileImageURIWithSig: Array<Eip712TypedDataField>;
+};
+
+/** The set profile uri eip 712 typed data value */
+export type CreateSetProfileImageUriEip712TypedDataValue = {
+  __typename?: "CreateSetProfileImageUriEIP712TypedDataValue";
+  deadline: Scalars["UnixTimestamp"];
+  imageURI: Scalars["Url"];
+  nonce: Scalars["Nonce"];
+  profileId: Scalars["ProfileId"];
+};
+
+/** The broadcast item */
+export type CreateSetProfileMetadataUriBroadcastItemResult = {
+  __typename?: "CreateSetProfileMetadataURIBroadcastItemResult";
+  /** The date the broadcast item expiries */
+  expiresAt: Scalars["DateTime"];
+  /** This broadcast item ID */
+  id: Scalars["BroadcastId"];
+  /** The typed data */
+  typedData: CreateSetProfileMetadataUrieip712TypedData;
+};
+
+/** The set follow nft uri eip 712 typed data */
+export type CreateSetProfileMetadataUrieip712TypedData = {
+  __typename?: "CreateSetProfileMetadataURIEIP712TypedData";
+  /** The typed data domain */
+  domain: Eip712TypedDataDomain;
+  /** The types */
+  types: CreateSetProfileMetadataUrieip712TypedDataTypes;
+  /** The values */
+  value: CreateSetProfileMetadataUrieip712TypedDataValue;
+};
+
+/** The set follow nft uri eip 712 typed data types */
+export type CreateSetProfileMetadataUrieip712TypedDataTypes = {
+  __typename?: "CreateSetProfileMetadataURIEIP712TypedDataTypes";
+  SetProfileMetadataURIWithSig: Array<Eip712TypedDataField>;
+};
+
+/** The set follow nft uri eip 712 typed data value */
+export type CreateSetProfileMetadataUrieip712TypedDataValue = {
+  __typename?: "CreateSetProfileMetadataURIEIP712TypedDataValue";
+  deadline: Scalars["UnixTimestamp"];
+  metadata: Scalars["Url"];
+  nonce: Scalars["Nonce"];
+  profileId: Scalars["ProfileId"];
+};
+
+/** The broadcast item */
+export type CreateToggleFollowBroadcastItemResult = {
+  __typename?: "CreateToggleFollowBroadcastItemResult";
+  /** The date the broadcast item expiries */
+  expiresAt: Scalars["DateTime"];
+  /** This broadcast item ID */
+  id: Scalars["BroadcastId"];
+  /** The typed data */
+  typedData: CreateToggleFollowEip712TypedData;
+};
+
+/** The create toggle follows eip 712 typed data */
+export type CreateToggleFollowEip712TypedData = {
+  __typename?: "CreateToggleFollowEIP712TypedData";
+  /** The typed data domain */
+  domain: Eip712TypedDataDomain;
+  /** The types */
+  types: CreateToggleFollowEip712TypedDataTypes;
+  /** The values */
+  value: CreateToggleFollowEip712TypedDataValue;
+};
+
+/** The create toggle follows eip 712 typed data types */
+export type CreateToggleFollowEip712TypedDataTypes = {
+  __typename?: "CreateToggleFollowEIP712TypedDataTypes";
+  ToggleFollowWithSig: Array<Eip712TypedDataField>;
+};
+
+/** The create toggle follow eip 712 typed data value */
+export type CreateToggleFollowEip712TypedDataValue = {
+  __typename?: "CreateToggleFollowEIP712TypedDataValue";
+  deadline: Scalars["UnixTimestamp"];
+  enables: Array<Scalars["Boolean"]>;
+  nonce: Scalars["Nonce"];
+  profileIds: Array<Scalars["ProfileId"]>;
+};
+
+export type CreateToggleFollowRequest = {
+  enables: Array<Scalars["Boolean"]>;
+  profileIds: Array<Scalars["ProfileId"]>;
+};
+
+/** The broadcast item */
+export type CreateUnfollowBroadcastItemResult = {
+  __typename?: "CreateUnfollowBroadcastItemResult";
+  /** The date the broadcast item expiries */
+  expiresAt: Scalars["DateTime"];
+  /** This broadcast item ID */
+  id: Scalars["BroadcastId"];
+  /** The typed data */
+  typedData: CreateBurnEip712TypedData;
+};
+
+/** The custom filters types */
+export enum CustomFiltersTypes {
+  Gardeners = "GARDENERS",
+}
+
+export type DefaultProfileRequest = {
+  ethereumAddress: Scalars["EthereumAddress"];
+};
+
+export type DegreesOfSeparationReferenceModuleParams = {
+  /** Applied to comments */
+  commentsRestricted: Scalars["Boolean"];
+  /** Degrees of separation */
+  degreesOfSeparation: Scalars["Int"];
+  /** Applied to mirrors */
+  mirrorsRestricted: Scalars["Boolean"];
+};
+
+export type DegreesOfSeparationReferenceModuleSettings = {
+  __typename?: "DegreesOfSeparationReferenceModuleSettings";
+  /** Applied to comments */
+  commentsRestricted: Scalars["Boolean"];
+  contractAddress: Scalars["ContractAddress"];
+  /** Degrees of separation */
+  degreesOfSeparation: Scalars["Int"];
+  /** Applied to mirrors */
+  mirrorsRestricted: Scalars["Boolean"];
+  /** The reference modules enum */
+  type: ReferenceModules;
+};
+
+/** The dispatcher */
+export type Dispatcher = {
+  __typename?: "Dispatcher";
+  /** The dispatcher address */
+  address: Scalars["EthereumAddress"];
+  /** If the dispatcher can use the relay */
+  canUseRelay: Scalars["Boolean"];
+};
+
+export type DoesFollow = {
+  /** The follower address remember wallets follow profiles */
+  followerAddress: Scalars["EthereumAddress"];
+  /** The profile id */
+  profileId: Scalars["ProfileId"];
+};
+
+export type DoesFollowRequest = {
+  /** The follower infos */
+  followInfos: Array<DoesFollow>;
+};
+
+/** The does follow response */
+export type DoesFollowResponse = {
+  __typename?: "DoesFollowResponse";
+  /** The follower address remember wallets follow profiles */
+  followerAddress: Scalars["EthereumAddress"];
+  /** If the user does follow */
+  follows: Scalars["Boolean"];
+  /** The profile id */
+  profileId: Scalars["ProfileId"];
+};
+
+/** The eip 712 typed data domain */
+export type Eip712TypedDataDomain = {
+  __typename?: "EIP712TypedDataDomain";
+  /** The chainId */
+  chainId: Scalars["ChainId"];
+  /** The name of the typed data domain */
+  name: Scalars["String"];
+  /** The verifying contract */
+  verifyingContract: Scalars["ContractAddress"];
+  /** The version */
+  version: Scalars["String"];
+};
+
+/** The eip 712 typed data field */
+export type Eip712TypedDataField = {
+  __typename?: "EIP712TypedDataField";
+  /** The name of the typed data field */
+  name: Scalars["String"];
+  /** The type of the typed data field */
+  type: Scalars["String"];
+};
+
+export type ElectedMirror = {
+  __typename?: "ElectedMirror";
+  mirrorId: Scalars["InternalPublicationId"];
+  profile: Profile;
+  timestamp: Scalars["DateTime"];
+};
+
+export type EnabledModule = {
+  __typename?: "EnabledModule";
+  contractAddress: Scalars["ContractAddress"];
+  inputParams: Array<ModuleInfo>;
+  moduleName: Scalars["String"];
+  redeemParams: Array<ModuleInfo>;
+  returnDataParms: Array<ModuleInfo>;
+};
+
+/** The enabled modules */
+export type EnabledModules = {
+  __typename?: "EnabledModules";
+  collectModules: Array<EnabledModule>;
+  followModules: Array<EnabledModule>;
+  referenceModules: Array<EnabledModule>;
+};
+
+export type EnsOnChainIdentity = {
+  __typename?: "EnsOnChainIdentity";
+  /** The default ens mapped to this address */
+  name?: Maybe<Scalars["Ens"]>;
+};
+
+/** The erc20 type */
+export type Erc20 = {
+  __typename?: "Erc20";
+  /** The erc20 address */
+  address: Scalars["ContractAddress"];
+  /** Decimal places for the token */
+  decimals: Scalars["Int"];
+  /** Name of the symbol */
+  name: Scalars["String"];
+  /** Symbol for the token */
+  symbol: Scalars["String"];
+};
+
+export type Erc20Amount = {
+  __typename?: "Erc20Amount";
+  /** The erc20 token info */
+  asset: Erc20;
+  /** Floating point number as string (e.g. 42.009837). It could have the entire precision of the Asset or be truncated to the last significant decimal. */
+  value: Scalars["String"];
+};
+
+/** The paginated publication result */
+export type ExploreProfileResult = {
+  __typename?: "ExploreProfileResult";
+  items: Array<Profile>;
+  pageInfo: PaginatedResultInfo;
+};
+
+export type ExploreProfilesRequest = {
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  customFilters?: InputMaybe<Array<CustomFiltersTypes>>;
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+  sortCriteria: ProfileSortCriteria;
+  timestamp?: InputMaybe<Scalars["TimestampScalar"]>;
+};
+
+export type ExplorePublicationRequest = {
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  customFilters?: InputMaybe<Array<CustomFiltersTypes>>;
+  /** If you wish to exclude any results for profile ids */
+  excludeProfileIds?: InputMaybe<Array<Scalars["ProfileId"]>>;
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+  metadata?: InputMaybe<PublicationMetadataFilters>;
+  /** If you want the randomizer off (default on) */
+  noRandomize?: InputMaybe<Scalars["Boolean"]>;
+  /** The publication types you want to query */
+  publicationTypes?: InputMaybe<Array<PublicationTypes>>;
+  sortCriteria: PublicationSortCriteria;
+  /** The App Id */
+  sources?: InputMaybe<Array<Scalars["Sources"]>>;
+  timestamp?: InputMaybe<Scalars["TimestampScalar"]>;
+};
+
+/** The paginated publication result */
+export type ExplorePublicationResult = {
+  __typename?: "ExplorePublicationResult";
+  items: Array<Publication>;
+  pageInfo: PaginatedResultInfo;
+};
+
+export type FeeCollectModuleParams = {
+  /** The collect module amount info */
+  amount: ModuleFeeAmountParams;
+  /** Follower only */
+  followerOnly: Scalars["Boolean"];
+  /** The collect module recipient address */
+  recipient: Scalars["EthereumAddress"];
+  /** The collect module referral fee */
+  referralFee: Scalars["Float"];
+};
+
+export type FeeCollectModuleSettings = {
+  __typename?: "FeeCollectModuleSettings";
+  /** The collect module amount info */
+  amount: ModuleFeeAmount;
+  contractAddress: Scalars["ContractAddress"];
+  /** Follower only */
+  followerOnly: Scalars["Boolean"];
+  /** The collect module recipient address */
+  recipient: Scalars["EthereumAddress"];
+  /** The collect module referral fee */
+  referralFee: Scalars["Float"];
+  /** The collect modules enum */
+  type: CollectModules;
+};
+
+export type FeeFollowModuleParams = {
+  /** The follow module amount info */
+  amount: ModuleFeeAmountParams;
+  /** The follow module recipient address */
+  recipient: Scalars["EthereumAddress"];
+};
+
+export type FeeFollowModuleRedeemParams = {
+  /** The expected amount to pay */
+  amount: ModuleFeeAmountParams;
+};
+
+export type FeeFollowModuleSettings = {
+  __typename?: "FeeFollowModuleSettings";
+  /** The collect module amount info */
+  amount: ModuleFeeAmount;
+  contractAddress: Scalars["ContractAddress"];
+  /** The collect module recipient address */
+  recipient: Scalars["EthereumAddress"];
+  /** The follow modules enum */
+  type: FollowModules;
+};
+
+/** The feed event item filter types */
+export enum FeedEventItemType {
+  CollectComment = "COLLECT_COMMENT",
+  CollectPost = "COLLECT_POST",
+  Comment = "COMMENT",
+  Mirror = "MIRROR",
+  Post = "POST",
+  ReactionComment = "REACTION_COMMENT",
+  ReactionPost = "REACTION_POST",
+}
+
+export type FeedHighlightsRequest = {
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+  metadata?: InputMaybe<PublicationMetadataFilters>;
+  /** The profile id */
+  profileId: Scalars["ProfileId"];
+  /** The App Id */
+  sources?: InputMaybe<Array<Scalars["Sources"]>>;
+};
+
+export type FeedItem = {
+  __typename?: "FeedItem";
+  /** Sorted by most recent first. Resolves defaultProfile and if null omits the wallet collect event from the list. */
+  collects: Array<CollectedEvent>;
+  /** Sorted by most recent first. Up to page size - 1 comments. */
+  comments?: Maybe<Array<Comment>>;
+  /** The elected mirror will be the first Mirror publication within the page results set */
+  electedMirror?: Maybe<ElectedMirror>;
+  /** Sorted by most recent first. Up to page size - 1 mirrors */
+  mirrors: Array<MirrorEvent>;
+  /** Sorted by most recent first. Up to page size - 1 reactions */
+  reactions: Array<ReactionEvent>;
+  root: FeedItemRoot;
+};
+
+export type FeedItemRoot = Comment | Post;
+
+export type FeedRequest = {
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  /** Filter your feed to whatever you wish */
+  feedEventItemTypes?: InputMaybe<Array<FeedEventItemType>>;
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+  metadata?: InputMaybe<PublicationMetadataFilters>;
+  /** The profile id */
+  profileId: Scalars["ProfileId"];
+  /** The App Id */
+  sources?: InputMaybe<Array<Scalars["Sources"]>>;
+};
+
+export type Follow = {
+  followModule?: InputMaybe<FollowModuleRedeemParams>;
+  profile: Scalars["ProfileId"];
+};
+
+export type FollowModule =
+  | FeeFollowModuleSettings
+  | ProfileFollowModuleSettings
+  | RevertFollowModuleSettings
+  | UnknownFollowModuleSettings;
+
+export type FollowModuleParams = {
+  /** The follower fee follower module */
+  feeFollowModule?: InputMaybe<FeeFollowModuleParams>;
+  /** The empty follow module */
+  freeFollowModule?: InputMaybe<Scalars["Boolean"]>;
+  /** The profile follow module */
+  profileFollowModule?: InputMaybe<Scalars["Boolean"]>;
+  /** The revert follow module */
+  revertFollowModule?: InputMaybe<Scalars["Boolean"]>;
+  /** A unknown follow module */
+  unknownFollowModule?: InputMaybe<UnknownFollowModuleParams>;
+};
+
+export type FollowModuleRedeemParams = {
+  /** The follower fee follower module */
+  feeFollowModule?: InputMaybe<FeeFollowModuleRedeemParams>;
+  /** The profile follower module */
+  profileFollowModule?: InputMaybe<ProfileFollowModuleRedeemParams>;
+  /** A unknown follow module */
+  unknownFollowModule?: InputMaybe<UnknownFollowModuleRedeemParams>;
+};
+
+/** The follow module types */
+export enum FollowModules {
+  FeeFollowModule = "FeeFollowModule",
+  ProfileFollowModule = "ProfileFollowModule",
+  RevertFollowModule = "RevertFollowModule",
+  UnknownFollowModule = "UnknownFollowModule",
+}
+
+export type FollowOnlyReferenceModuleSettings = {
+  __typename?: "FollowOnlyReferenceModuleSettings";
+  contractAddress: Scalars["ContractAddress"];
+  /** The reference modules enum */
+  type: ReferenceModules;
+};
+
+export type FollowProxyAction = {
+  freeFollow?: InputMaybe<FreeFollowProxyAction>;
+};
+
+export type FollowRequest = {
+  follow: Array<Follow>;
+};
+
+export type FollowRevenueResult = {
+  __typename?: "FollowRevenueResult";
+  revenues: Array<RevenueAggregate>;
+};
+
+export type Follower = {
+  __typename?: "Follower";
+  totalAmountOfTimesFollowed: Scalars["Int"];
+  wallet: Wallet;
+};
+
+export type FollowerNftOwnedTokenIds = {
+  __typename?: "FollowerNftOwnedTokenIds";
+  followerNftAddress: Scalars["ContractAddress"];
+  tokensIds: Array<Scalars["String"]>;
+};
+
+export type FollowerNftOwnedTokenIdsRequest = {
+  address: Scalars["EthereumAddress"];
+  profileId: Scalars["ProfileId"];
+};
+
+export type FollowersRequest = {
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+  profileId: Scalars["ProfileId"];
+};
+
+export type Following = {
+  __typename?: "Following";
+  profile: Profile;
+  totalAmountOfTimesFollowing: Scalars["Int"];
+};
+
+export type FollowingRequest = {
+  address: Scalars["EthereumAddress"];
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+};
+
+export type FraudReasonInputParams = {
+  reason: PublicationReportingReason;
+  subreason: PublicationReportingFraudSubreason;
+};
+
+export type FreeCollectModuleParams = {
+  /** Follower only */
+  followerOnly: Scalars["Boolean"];
+};
+
+export type FreeCollectModuleSettings = {
+  __typename?: "FreeCollectModuleSettings";
+  contractAddress: Scalars["ContractAddress"];
+  /** Follower only */
+  followerOnly: Scalars["Boolean"];
+  /** The collect modules enum */
+  type: CollectModules;
+};
+
+export type FreeCollectProxyAction = {
+  publicationId: Scalars["InternalPublicationId"];
+};
+
+export type FreeFollowProxyAction = {
+  profileId: Scalars["ProfileId"];
+};
+
+export type GenerateModuleCurrencyApproval = {
+  __typename?: "GenerateModuleCurrencyApproval";
+  data: Scalars["BlockchainData"];
+  from: Scalars["EthereumAddress"];
+  to: Scalars["ContractAddress"];
+};
+
+export type GenerateModuleCurrencyApprovalDataRequest = {
+  collectModule?: InputMaybe<CollectModules>;
+  currency: Scalars["ContractAddress"];
+  followModule?: InputMaybe<FollowModules>;
+  referenceModule?: InputMaybe<ReferenceModules>;
+  unknownCollectModule?: InputMaybe<Scalars["ContractAddress"]>;
+  unknownFollowModule?: InputMaybe<Scalars["ContractAddress"]>;
+  unknownReferenceModule?: InputMaybe<Scalars["ContractAddress"]>;
+  /** Floating point number as string (e.g. 42.009837). The server will move its decimal places for you */
+  value: Scalars["String"];
+};
+
+export type GetPublicationMetadataStatusRequest = {
+  publicationId?: InputMaybe<Scalars["InternalPublicationId"]>;
+  txHash?: InputMaybe<Scalars["TxHash"]>;
+  txId?: InputMaybe<Scalars["TxId"]>;
+};
+
+export type GlobalProtocolStats = {
+  __typename?: "GlobalProtocolStats";
+  totalBurntProfiles: Scalars["Int"];
+  totalCollects: Scalars["Int"];
+  totalComments: Scalars["Int"];
+  totalFollows: Scalars["Int"];
+  totalMirrors: Scalars["Int"];
+  totalPosts: Scalars["Int"];
+  totalProfiles: Scalars["Int"];
+  totalRevenue: Array<Erc20Amount>;
+};
+
+export type GlobalProtocolStatsRequest = {
+  /** Unix time from timestamp - if not supplied it will go from 0 timestamp */
+  fromTimestamp?: InputMaybe<Scalars["UnixTimestamp"]>;
+  /** The App Id */
+  sources?: InputMaybe<Array<Scalars["Sources"]>>;
+  /** Unix time to timestamp - if not supplied it go to the present timestamp */
+  toTimestamp?: InputMaybe<Scalars["UnixTimestamp"]>;
+};
+
+export type HasTxHashBeenIndexedRequest = {
+  /** Tx hash.. if your using the broadcaster you should use txId due to gas price upgrades */
+  txHash?: InputMaybe<Scalars["TxHash"]>;
+  /** Tx id.. if your using the broadcaster you should always use this field */
+  txId?: InputMaybe<Scalars["TxId"]>;
+};
+
+export type HidePublicationRequest = {
+  /** Publication id */
+  publicationId: Scalars["InternalPublicationId"];
+};
+
+export type IllegalReasonInputParams = {
+  reason: PublicationReportingReason;
+  subreason: PublicationReportingIllegalSubreason;
+};
+
+export type InternalPublicationsFilterRequest = {
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  /** must be DD/MM/YYYY */
+  fromDate: Scalars["String"];
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+  /** The shared secret */
+  secret: Scalars["String"];
+  /** The App Id */
+  source: Scalars["Sources"];
+  /** must be DD/MM/YYYY */
+  toDate: Scalars["String"];
+};
+
+export type LimitedFeeCollectModuleParams = {
+  /** The collect module amount info */
+  amount: ModuleFeeAmountParams;
+  /** The collect module limit */
+  collectLimit: Scalars["String"];
+  /** Follower only */
+  followerOnly: Scalars["Boolean"];
+  /** The collect module recipient address */
+  recipient: Scalars["EthereumAddress"];
+  /** The collect module referral fee */
+  referralFee: Scalars["Float"];
+};
+
+export type LimitedFeeCollectModuleSettings = {
+  __typename?: "LimitedFeeCollectModuleSettings";
+  /** The collect module amount info */
+  amount: ModuleFeeAmount;
+  /** The collect module limit */
+  collectLimit: Scalars["String"];
+  contractAddress: Scalars["ContractAddress"];
+  /** Follower only */
+  followerOnly: Scalars["Boolean"];
+  /** The collect module recipient address */
+  recipient: Scalars["EthereumAddress"];
+  /** The collect module referral fee */
+  referralFee: Scalars["Float"];
+  /** The collect modules enum */
+  type: CollectModules;
+};
+
+export type LimitedTimedFeeCollectModuleParams = {
+  /** The collect module amount info */
+  amount: ModuleFeeAmountParams;
+  /** The collect module limit */
+  collectLimit: Scalars["String"];
+  /** Follower only */
+  followerOnly: Scalars["Boolean"];
+  /** The collect module recipient address */
+  recipient: Scalars["EthereumAddress"];
+  /** The collect module referral fee */
+  referralFee: Scalars["Float"];
+};
+
+export type LimitedTimedFeeCollectModuleSettings = {
+  __typename?: "LimitedTimedFeeCollectModuleSettings";
+  /** The collect module amount info */
+  amount: ModuleFeeAmount;
+  /** The collect module limit */
+  collectLimit: Scalars["String"];
+  contractAddress: Scalars["ContractAddress"];
+  /** The collect module end timestamp */
+  endTimestamp: Scalars["DateTime"];
+  /** Follower only */
+  followerOnly: Scalars["Boolean"];
+  /** The collect module recipient address */
+  recipient: Scalars["EthereumAddress"];
+  /** The collect module referral fee */
+  referralFee: Scalars["Float"];
+  /** The collect modules enum */
+  type: CollectModules;
+};
+
+export type Log = {
+  __typename?: "Log";
+  address: Scalars["ContractAddress"];
+  blockHash: Scalars["String"];
+  blockNumber: Scalars["Int"];
+  data: Scalars["String"];
+  logIndex: Scalars["Int"];
+  removed: Scalars["Boolean"];
+  topics: Array<Scalars["String"]>;
+  transactionHash: Scalars["TxHash"];
+  transactionIndex: Scalars["Int"];
+};
+
+export type MainPostReference = Mirror | Post;
+
+/** The Media url */
+export type Media = {
+  __typename?: "Media";
+  /** The alt tags for accessibility */
+  altTag?: Maybe<Scalars["String"]>;
+  /** The cover for any video or audio you attached */
+  cover?: Maybe<Scalars["String"]>;
+  /** Height - will always be null on the public API */
+  height?: Maybe<Scalars["Int"]>;
+  /** The image/audio/video mime type for the publication */
+  mimeType?: Maybe<Scalars["MimeType"]>;
+  /** Size - will always be null on the public API */
+  size?: Maybe<Scalars["Int"]>;
+  /** The token image nft */
+  url: Scalars["Url"];
+  /** Width - will always be null on the public API */
+  width?: Maybe<Scalars["Int"]>;
+};
+
+/** The Media Set */
+export type MediaSet = {
+  __typename?: "MediaSet";
+  /**
+   * Medium media - will always be null on the public API
+   * @deprecated should not be used will always be null
+   */
+  medium?: Maybe<Media>;
+  /** Original media */
+  original: Media;
+  /**
+   * Small media - will always be null on the public API
+   * @deprecated should not be used will always be null
+   */
+  small?: Maybe<Media>;
+};
+
+export type MentionPublication = Comment | Post;
+
+/** The metadata attribute input */
+export type MetadataAttributeInput = {
+  /** The display type */
+  displayType?: InputMaybe<PublicationMetadataDisplayTypes>;
+  /** The trait type - can be anything its the name it will render so include spaces */
+  traitType: Scalars["String"];
+  /** The value */
+  value: Scalars["String"];
+};
+
+/** The metadata attribute output */
+export type MetadataAttributeOutput = {
+  __typename?: "MetadataAttributeOutput";
+  /** The display type */
+  displayType?: Maybe<PublicationMetadataDisplayTypes>;
+  /** The trait type - can be anything its the name it will render so include spaces */
+  traitType?: Maybe<Scalars["String"]>;
+  /** The value */
+  value?: Maybe<Scalars["String"]>;
+};
+
+/** The metadata output */
+export type MetadataOutput = {
+  __typename?: "MetadataOutput";
+  /** The main focus of the publication */
+  animatedUrl?: Maybe<Scalars["Url"]>;
+  /** The attributes */
+  attributes: Array<MetadataAttributeOutput>;
+  /** This is the metadata content for the publication, should be markdown */
+  content?: Maybe<Scalars["Markdown"]>;
+  /** The content warning for the publication */
+  contentWarning?: Maybe<PublicationContentWarning>;
+  /** The image cover for video/music publications */
+  cover?: Maybe<MediaSet>;
+  /** This is the metadata description */
+  description?: Maybe<Scalars["Markdown"]>;
+  /** This is the image attached to the metadata and the property used to show the NFT! */
+  image?: Maybe<Scalars["Url"]>;
+  /** The locale of the publication,  */
+  locale?: Maybe<Scalars["Locale"]>;
+  /** The main focus of the publication */
+  mainContentFocus: PublicationMainFocus;
+  /** The images/audios/videos for the publication */
+  media: Array<MediaSet>;
+  /** The metadata name */
+  name?: Maybe<Scalars["String"]>;
+  /** The tags for the publication */
+  tags: Array<Scalars["String"]>;
+};
+
+/** The social mirror */
+export type Mirror = {
+  __typename?: "Mirror";
+  /** ID of the source */
+  appId?: Maybe<Scalars["Sources"]>;
+  canComment: CanCommentResponse;
+  canMirror: CanMirrorResponse;
+  /** The collect module */
+  collectModule: CollectModule;
+  /** The contract address for the collect nft.. if its null it means nobody collected yet as it lazy deployed */
+  collectNftAddress?: Maybe<Scalars["ContractAddress"]>;
+  /** The date the post was created on */
+  createdAt: Scalars["DateTime"];
+  hasCollectedByMe: Scalars["Boolean"];
+  /** If the publication has been hidden if it has then the content and media is not available */
+  hidden: Scalars["Boolean"];
+  /** The internal publication id */
+  id: Scalars["InternalPublicationId"];
+  /** The metadata for the post */
+  metadata: MetadataOutput;
+  /** The mirror publication */
+  mirrorOf: MirrorablePublication;
+  /** The on chain content uri could be `ipfs://` or `https` */
+  onChainContentURI: Scalars["String"];
+  /** The profile ref */
+  profile: Profile;
+  reaction?: Maybe<ReactionTypes>;
+  /** The reference module */
+  referenceModule?: Maybe<ReferenceModule>;
+  /** The publication stats */
+  stats: PublicationStats;
+};
+
+/** The social mirror */
+export type MirrorCanCommentArgs = {
+  profileId?: InputMaybe<Scalars["ProfileId"]>;
+};
+
+/** The social mirror */
+export type MirrorCanMirrorArgs = {
+  profileId?: InputMaybe<Scalars["ProfileId"]>;
+};
+
+/** The social mirror */
+export type MirrorReactionArgs = {
+  request?: InputMaybe<ReactionFieldResolverRequest>;
+};
+
+export type MirrorEvent = {
+  __typename?: "MirrorEvent";
+  profile: Profile;
+  timestamp: Scalars["DateTime"];
+};
+
+export type MirrorablePublication = Comment | Post;
+
+export type ModuleFeeAmount = {
+  __typename?: "ModuleFeeAmount";
+  /** The erc20 token info */
+  asset: Erc20;
+  /** Floating point number as string (e.g. 42.009837). It could have the entire precision of the Asset or be truncated to the last significant decimal. */
+  value: Scalars["String"];
+};
+
+export type ModuleFeeAmountParams = {
+  /** The currency address */
+  currency: Scalars["ContractAddress"];
+  /** Floating point number as string (e.g. 42.009837). It could have the entire precision of the Asset or be truncated to the last significant decimal. */
+  value: Scalars["String"];
+};
+
+export type ModuleInfo = {
+  __typename?: "ModuleInfo";
+  name: Scalars["String"];
+  type: Scalars["String"];
+};
+
+export type Mutation = {
+  __typename?: "Mutation";
+  ach?: Maybe<Scalars["Void"]>;
+  addReaction?: Maybe<Scalars["Void"]>;
+  authenticate: AuthenticationResult;
+  broadcast: RelayResult;
+  claim: RelayResult;
+  createBurnProfileTypedData: CreateBurnProfileBroadcastItemResult;
+  createCollectTypedData: CreateCollectBroadcastItemResult;
+  createCommentTypedData: CreateCommentBroadcastItemResult;
+  createCommentViaDispatcher: RelayResult;
+  createFollowTypedData: CreateFollowBroadcastItemResult;
+  createMirrorTypedData: CreateMirrorBroadcastItemResult;
+  createMirrorViaDispatcher: RelayResult;
+  createPostTypedData: CreatePostBroadcastItemResult;
+  createPostViaDispatcher: RelayResult;
+  createSetDefaultProfileTypedData: SetDefaultProfileBroadcastItemResult;
+  createSetDispatcherTypedData: CreateSetDispatcherBroadcastItemResult;
+  createSetFollowModuleTypedData: CreateSetFollowModuleBroadcastItemResult;
+  createSetFollowNFTUriTypedData: CreateSetFollowNftUriBroadcastItemResult;
+  createSetProfileImageURITypedData: CreateSetProfileImageUriBroadcastItemResult;
+  createSetProfileImageURIViaDispatcher: RelayResult;
+  createSetProfileMetadataTypedData: CreateSetProfileMetadataUriBroadcastItemResult;
+  createSetProfileMetadataViaDispatcher: RelayResult;
+  createToggleFollowTypedData: CreateToggleFollowBroadcastItemResult;
+  createUnfollowTypedData: CreateUnfollowBroadcastItemResult;
+  hidePublication?: Maybe<Scalars["Void"]>;
+  proxyAction: Scalars["ProxyActionId"];
+  refresh: AuthenticationResult;
+  removeReaction?: Maybe<Scalars["Void"]>;
+  reportPublication?: Maybe<Scalars["Void"]>;
+};
+
+export type MutationAchArgs = {
+  request: AchRequest;
+};
+
+export type MutationAddReactionArgs = {
+  request: ReactionRequest;
+};
+
+export type MutationAuthenticateArgs = {
+  request: SignedAuthChallenge;
+};
+
+export type MutationBroadcastArgs = {
+  request: BroadcastRequest;
+};
+
+export type MutationClaimArgs = {
+  request: ClaimHandleRequest;
+};
+
+export type MutationCreateBurnProfileTypedDataArgs = {
+  options?: InputMaybe<TypedDataOptions>;
+  request: BurnProfileRequest;
+};
+
+export type MutationCreateCollectTypedDataArgs = {
+  options?: InputMaybe<TypedDataOptions>;
+  request: CreateCollectRequest;
+};
+
+export type MutationCreateCommentTypedDataArgs = {
+  options?: InputMaybe<TypedDataOptions>;
+  request: CreatePublicCommentRequest;
+};
+
+export type MutationCreateCommentViaDispatcherArgs = {
+  request: CreatePublicCommentRequest;
+};
+
+export type MutationCreateFollowTypedDataArgs = {
+  options?: InputMaybe<TypedDataOptions>;
+  request: FollowRequest;
+};
+
+export type MutationCreateMirrorTypedDataArgs = {
+  options?: InputMaybe<TypedDataOptions>;
+  request: CreateMirrorRequest;
+};
+
+export type MutationCreateMirrorViaDispatcherArgs = {
+  request: CreateMirrorRequest;
+};
+
+export type MutationCreatePostTypedDataArgs = {
+  options?: InputMaybe<TypedDataOptions>;
+  request: CreatePublicPostRequest;
+};
+
+export type MutationCreatePostViaDispatcherArgs = {
+  request: CreatePublicPostRequest;
+};
+
+export type MutationCreateSetDefaultProfileTypedDataArgs = {
+  options?: InputMaybe<TypedDataOptions>;
+  request: CreateSetDefaultProfileRequest;
+};
+
+export type MutationCreateSetDispatcherTypedDataArgs = {
+  options?: InputMaybe<TypedDataOptions>;
+  request: SetDispatcherRequest;
+};
+
+export type MutationCreateSetFollowModuleTypedDataArgs = {
+  options?: InputMaybe<TypedDataOptions>;
+  request: CreateSetFollowModuleRequest;
+};
+
+export type MutationCreateSetFollowNftUriTypedDataArgs = {
+  options?: InputMaybe<TypedDataOptions>;
+  request: CreateSetFollowNftUriRequest;
+};
+
+export type MutationCreateSetProfileImageUriTypedDataArgs = {
+  options?: InputMaybe<TypedDataOptions>;
+  request: UpdateProfileImageRequest;
+};
+
+export type MutationCreateSetProfileImageUriViaDispatcherArgs = {
+  request: UpdateProfileImageRequest;
+};
+
+export type MutationCreateSetProfileMetadataTypedDataArgs = {
+  options?: InputMaybe<TypedDataOptions>;
+  request: CreatePublicSetProfileMetadataUriRequest;
+};
+
+export type MutationCreateSetProfileMetadataViaDispatcherArgs = {
+  request: CreatePublicSetProfileMetadataUriRequest;
+};
+
+export type MutationCreateToggleFollowTypedDataArgs = {
+  options?: InputMaybe<TypedDataOptions>;
+  request: CreateToggleFollowRequest;
+};
+
+export type MutationCreateUnfollowTypedDataArgs = {
+  options?: InputMaybe<TypedDataOptions>;
+  request: UnfollowRequest;
+};
+
+export type MutationHidePublicationArgs = {
+  request: HidePublicationRequest;
+};
+
+export type MutationProxyActionArgs = {
+  request: ProxyActionRequest;
+};
+
+export type MutationRefreshArgs = {
+  request: RefreshRequest;
+};
+
+export type MutationRemoveReactionArgs = {
+  request: ReactionRequest;
+};
+
+export type MutationReportPublicationArgs = {
+  request: ReportPublicationRequest;
+};
+
+export type MutualFollowersProfilesQueryRequest = {
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+  /** The profile id your viewing */
+  viewingProfileId: Scalars["ProfileId"];
+  /** The profile id you want the result to come back as your viewing from */
+  yourProfileId: Scalars["ProfileId"];
+};
+
+/** The nft type */
+export type Nft = {
+  __typename?: "NFT";
+  /** aka "1"  */
+  chainId: Scalars["ChainId"];
+  /** aka "CryptoKitties"  */
+  collectionName: Scalars["String"];
+  /** aka "https://api.criptokitt..."  */
+  contentURI: Scalars["String"];
+  /** aka 0x057Ec652A4F150f7FF94f089A38008f49a0DF88e  */
+  contractAddress: Scalars["ContractAddress"];
+  /** aka us CryptoKitties */
+  contractName: Scalars["String"];
+  /** aka "Hey cutie! I m Beard Coffee. ....  */
+  description: Scalars["String"];
+  /** aka "ERC721"  */
+  ercType: Scalars["String"];
+  /** aka "Beard Coffee"  */
+  name: Scalars["String"];
+  /** aka "{ uri:"https://ipfs....", metaType:"image/png" }"  */
+  originalContent: NftContent;
+  /** aka { address: 0x057Ec652A4F150f7FF94f089A38008f49a0DF88e, amount:"2" }  */
+  owners: Array<Owner>;
+  /** aka RARI */
+  symbol: Scalars["String"];
+  /** aka "13"  */
+  tokenId: Scalars["String"];
+};
+
+/** The NFT content uri */
+export type NftContent = {
+  __typename?: "NFTContent";
+  /** The animated url */
+  animatedUrl?: Maybe<Scalars["String"]>;
+  /** The meta type content */
+  metaType: Scalars["String"];
+  /** The token uri  nft */
+  uri: Scalars["String"];
+};
+
+export type NftData = {
+  /** Id of the nft ownership challenge */
+  id: Scalars["NftOwnershipId"];
+  /** The signature */
+  signature: Scalars["Signature"];
+};
+
+export type NfTsRequest = {
+  /** Chain Ids */
+  chainIds: Array<Scalars["ChainId"]>;
+  /** Filter by contract address */
+  contractAddress?: InputMaybe<Scalars["ContractAddress"]>;
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+  /** Filter by owner address */
+  ownerAddress: Scalars["EthereumAddress"];
+};
+
+/** Paginated nft results */
+export type NfTsResult = {
+  __typename?: "NFTsResult";
+  items: Array<Nft>;
+  pageInfo: PaginatedResultInfo;
+};
+
+export type NewCollectNotification = {
+  __typename?: "NewCollectNotification";
+  collectedPublication: Publication;
+  createdAt: Scalars["DateTime"];
+  notificationId: Scalars["NotificationId"];
+  wallet: Wallet;
+};
+
+export type NewCommentNotification = {
+  __typename?: "NewCommentNotification";
+  comment: Comment;
+  createdAt: Scalars["DateTime"];
+  notificationId: Scalars["NotificationId"];
+  /** The profile */
+  profile: Profile;
+};
+
+export type NewFollowerNotification = {
+  __typename?: "NewFollowerNotification";
+  createdAt: Scalars["DateTime"];
+  isFollowedByMe: Scalars["Boolean"];
+  notificationId: Scalars["NotificationId"];
+  wallet: Wallet;
+};
+
+export type NewMentionNotification = {
+  __typename?: "NewMentionNotification";
+  createdAt: Scalars["DateTime"];
+  mentionPublication: MentionPublication;
+  notificationId: Scalars["NotificationId"];
+};
+
+export type NewMirrorNotification = {
+  __typename?: "NewMirrorNotification";
+  createdAt: Scalars["DateTime"];
+  notificationId: Scalars["NotificationId"];
+  /** The profile */
+  profile: Profile;
+  publication: MirrorablePublication;
+};
+
+export type NewReactionNotification = {
+  __typename?: "NewReactionNotification";
+  createdAt: Scalars["DateTime"];
+  notificationId: Scalars["NotificationId"];
+  /** The profile */
+  profile: Profile;
+  publication: Publication;
+  reaction: ReactionTypes;
+};
+
+/** The NFT image */
+export type NftImage = {
+  __typename?: "NftImage";
+  /** The token image nft */
+  chainId: Scalars["Int"];
+  /** The contract address */
+  contractAddress: Scalars["ContractAddress"];
+  /** The token id of the nft */
+  tokenId: Scalars["String"];
+  /** The token image nft */
+  uri: Scalars["Url"];
+  /** If the NFT is verified */
+  verified: Scalars["Boolean"];
+};
+
+export type NftOwnershipChallenge = {
+  /** Chain Id */
+  chainId: Scalars["ChainId"];
+  /** ContractAddress for nft */
+  contractAddress: Scalars["ContractAddress"];
+  /** Token id for NFT */
+  tokenId: Scalars["String"];
+};
+
+export type NftOwnershipChallengeRequest = {
+  /** The wallet address which owns the NFT */
+  ethereumAddress: Scalars["EthereumAddress"];
+  nfts: Array<NftOwnershipChallenge>;
+};
+
+/** NFT ownership challenge result */
+export type NftOwnershipChallengeResult = {
+  __typename?: "NftOwnershipChallengeResult";
+  /** Id of the nft ownership challenge */
+  id: Scalars["NftOwnershipId"];
+  text: Scalars["String"];
+  /** Timeout of the validation */
+  timeout: Scalars["TimestampScalar"];
+};
+
+export type Notification =
+  | NewCollectNotification
+  | NewCommentNotification
+  | NewFollowerNotification
+  | NewMentionNotification
+  | NewMirrorNotification
+  | NewReactionNotification;
+
+export type NotificationRequest = {
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  customFilters?: InputMaybe<Array<CustomFiltersTypes>>;
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+  metadata?: InputMaybe<PublicationMetadataFilters>;
+  /** The profile id */
+  notificationTypes?: InputMaybe<Array<NotificationTypes>>;
+  /** The profile id */
+  profileId: Scalars["ProfileId"];
+  /** The App Id */
+  sources?: InputMaybe<Array<Scalars["Sources"]>>;
+};
+
+/** The notification filter types */
+export enum NotificationTypes {
+  CollectedComment = "COLLECTED_COMMENT",
+  CollectedPost = "COLLECTED_POST",
+  CommentedComment = "COMMENTED_COMMENT",
+  CommentedPost = "COMMENTED_POST",
+  Followed = "FOLLOWED",
+  MentionComment = "MENTION_COMMENT",
+  MentionPost = "MENTION_POST",
+  MirroredComment = "MIRRORED_COMMENT",
+  MirroredPost = "MIRRORED_POST",
+  ReactionComment = "REACTION_COMMENT",
+  ReactionPost = "REACTION_POST",
+}
+
+export type OnChainIdentity = {
+  __typename?: "OnChainIdentity";
+  /** The ens information */
+  ens?: Maybe<EnsOnChainIdentity>;
+  /** The POH status */
+  proofOfHumanity: Scalars["Boolean"];
+  /** The sybil dot org information */
+  sybilDotOrg: SybilDotOrgIdentity;
+  /** The worldcoin identity */
+  worldcoin: WorldcoinIdentity;
+};
+
+/** The nft type */
+export type Owner = {
+  __typename?: "Owner";
+  /** aka 0x057Ec652A4F150f7FF94f089A38008f49a0DF88e  */
+  address: Scalars["EthereumAddress"];
+  /** number of tokens owner */
+  amount: Scalars["Float"];
+};
+
+/** The paginated wallet result */
+export type PaginatedAllPublicationsTagsResult = {
+  __typename?: "PaginatedAllPublicationsTagsResult";
+  items: Array<TagResult>;
+  pageInfo: PaginatedResultInfo;
+};
+
+/** The paginated feed result */
+export type PaginatedFeedResult = {
+  __typename?: "PaginatedFeedResult";
+  items: Array<FeedItem>;
+  pageInfo: PaginatedResultInfo;
+};
+
+/** The paginated followers result */
+export type PaginatedFollowersResult = {
+  __typename?: "PaginatedFollowersResult";
+  items: Array<Follower>;
+  pageInfo: PaginatedResultInfo;
+};
+
+export type PaginatedFollowingResult = {
+  __typename?: "PaginatedFollowingResult";
+  items: Array<Following>;
+  pageInfo: PaginatedResultInfo;
+};
+
+/** The paginated notification result */
+export type PaginatedNotificationResult = {
+  __typename?: "PaginatedNotificationResult";
+  items: Array<Notification>;
+  pageInfo: PaginatedResultInfo;
+};
+
+/** The paginated wallet result */
+export type PaginatedProfilePublicationsForSaleResult = {
+  __typename?: "PaginatedProfilePublicationsForSaleResult";
+  items: Array<PublicationForSale>;
+  pageInfo: PaginatedResultInfo;
+};
+
+/** The paginated profile result */
+export type PaginatedProfileResult = {
+  __typename?: "PaginatedProfileResult";
+  items: Array<Profile>;
+  pageInfo: PaginatedResultInfo;
+};
+
+/** The paginated publication result */
+export type PaginatedPublicationResult = {
+  __typename?: "PaginatedPublicationResult";
+  items: Array<Publication>;
+  pageInfo: PaginatedResultInfo;
+};
+
+/** The paginated result info */
+export type PaginatedResultInfo = {
+  __typename?: "PaginatedResultInfo";
+  /** Cursor to query next results */
+  next?: Maybe<Scalars["Cursor"]>;
+  /** Cursor to query the actual results */
+  prev?: Maybe<Scalars["Cursor"]>;
+  /** The total number of entities the pagination iterates over. If null it means it can not work it out due to dynamic or aggregated query e.g. For a query that requests all nfts with more than 10 likes, this field gives the total amount of nfts with more than 10 likes, not the total amount of nfts */
+  totalCount?: Maybe<Scalars["Int"]>;
+};
+
+/** The paginated timeline result */
+export type PaginatedTimelineResult = {
+  __typename?: "PaginatedTimelineResult";
+  items: Array<Publication>;
+  pageInfo: PaginatedResultInfo;
+};
+
+/** The paginated wallet result */
+export type PaginatedWhoCollectedResult = {
+  __typename?: "PaginatedWhoCollectedResult";
+  items: Array<Wallet>;
+  pageInfo: PaginatedResultInfo;
+};
+
+export type PaginatedWhoReactedResult = {
+  __typename?: "PaginatedWhoReactedResult";
+  items: Array<WhoReactedResult>;
+  pageInfo: PaginatedResultInfo;
+};
+
+export type PendingApprovalFollowsRequest = {
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+};
+
+/** The paginated follow result */
+export type PendingApproveFollowsResult = {
+  __typename?: "PendingApproveFollowsResult";
+  items: Array<Profile>;
+  pageInfo: PaginatedResultInfo;
+};
+
+/** The social post */
+export type Post = {
+  __typename?: "Post";
+  /** ID of the source */
+  appId?: Maybe<Scalars["Sources"]>;
+  canComment: CanCommentResponse;
+  canMirror: CanMirrorResponse;
+  /** The collect module */
+  collectModule: CollectModule;
+  /** The contract address for the collect nft.. if its null it means nobody collected yet as it lazy deployed */
+  collectNftAddress?: Maybe<Scalars["ContractAddress"]>;
+  /**
+   * Who collected it, this is used for timeline results and like this for better caching for the client
+   * @deprecated use `feed` query, timeline query will be killed on the 15th November. This includes this field.
+   */
+  collectedBy?: Maybe<Wallet>;
+  /** The date the post was created on */
+  createdAt: Scalars["DateTime"];
+  hasCollectedByMe: Scalars["Boolean"];
+  /** If the publication has been hidden if it has then the content and media is not available */
+  hidden: Scalars["Boolean"];
+  /** The internal publication id */
+  id: Scalars["InternalPublicationId"];
+  /** The metadata for the post */
+  metadata: MetadataOutput;
+  mirrors: Array<Scalars["InternalPublicationId"]>;
+  /** The on chain content uri could be `ipfs://` or `https` */
+  onChainContentURI: Scalars["String"];
+  /** The profile ref */
+  profile: Profile;
+  reaction?: Maybe<ReactionTypes>;
+  /** The reference module */
+  referenceModule?: Maybe<ReferenceModule>;
+  /** The publication stats */
+  stats: PublicationStats;
+};
+
+/** The social post */
+export type PostCanCommentArgs = {
+  profileId?: InputMaybe<Scalars["ProfileId"]>;
+};
+
+/** The social post */
+export type PostCanMirrorArgs = {
+  profileId?: InputMaybe<Scalars["ProfileId"]>;
+};
+
+/** The social post */
+export type PostMirrorsArgs = {
+  by?: InputMaybe<Scalars["ProfileId"]>;
+};
+
+/** The social post */
+export type PostReactionArgs = {
+  request?: InputMaybe<ReactionFieldResolverRequest>;
+};
+
+/** The Profile */
+export type Profile = {
+  __typename?: "Profile";
+  /** Optionals param to add extra attributes on the metadata */
+  attributes?: Maybe<Array<Attribute>>;
+  /** Bio of the profile */
+  bio?: Maybe<Scalars["String"]>;
+  /** The cover picture for the profile */
+  coverPicture?: Maybe<ProfileMedia>;
+  /** The dispatcher */
+  dispatcher?: Maybe<Dispatcher>;
+  /** The follow module */
+  followModule?: Maybe<FollowModule>;
+  /** Follow nft address */
+  followNftAddress?: Maybe<Scalars["ContractAddress"]>;
+  /** The profile handle */
+  handle: Scalars["Handle"];
+  /** The profile id */
+  id: Scalars["ProfileId"];
+  /** Is the profile default */
+  isDefault: Scalars["Boolean"];
+  isFollowedByMe: Scalars["Boolean"];
+  isFollowing: Scalars["Boolean"];
+  /** Metadata url */
+  metadata?: Maybe<Scalars["Url"]>;
+  /** Name of the profile */
+  name?: Maybe<Scalars["String"]>;
+  /** The on chain identity */
+  onChainIdentity: OnChainIdentity;
+  /** Who owns the profile */
+  ownedBy: Scalars["EthereumAddress"];
+  /** The picture for the profile */
+  picture?: Maybe<ProfileMedia>;
+  /** Profile stats */
+  stats: ProfileStats;
+};
+
+/** The Profile */
+export type ProfileIsFollowingArgs = {
+  who?: InputMaybe<Scalars["ProfileId"]>;
+};
+
+export type ProfileFollowModuleBeenRedeemedRequest = {
+  followProfileId: Scalars["ProfileId"];
+  redeemingProfileId: Scalars["ProfileId"];
+};
+
+export type ProfileFollowModuleRedeemParams = {
+  /** The profile id to use to follow this profile */
+  profileId: Scalars["ProfileId"];
+};
+
+export type ProfileFollowModuleSettings = {
+  __typename?: "ProfileFollowModuleSettings";
+  contractAddress: Scalars["ContractAddress"];
+  /** The follow module enum */
+  type: FollowModules;
+};
+
+export type ProfileFollowRevenueQueryRequest = {
+  /** The profile id */
+  profileId: Scalars["ProfileId"];
+};
+
+export type ProfileMedia = MediaSet | NftImage;
+
+export type ProfileOnChainIdentityRequest = {
+  profileIds: Array<Scalars["ProfileId"]>;
+};
+
+export type ProfilePublicationRevenueQueryRequest = {
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+  metadata?: InputMaybe<PublicationMetadataFilters>;
+  /** The profile id */
+  profileId: Scalars["ProfileId"];
+  /** The App Id */
+  sources?: InputMaybe<Array<Scalars["Sources"]>>;
+  /** The revenue types */
+  types?: InputMaybe<Array<PublicationTypes>>;
+};
+
+/** The paginated revenue result */
+export type ProfilePublicationRevenueResult = {
+  __typename?: "ProfilePublicationRevenueResult";
+  items: Array<PublicationRevenue>;
+  pageInfo: PaginatedResultInfo;
+};
+
+export type ProfilePublicationsForSaleRequest = {
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+  metadata?: InputMaybe<PublicationMetadataFilters>;
+  /** Profile id */
+  profileId: Scalars["ProfileId"];
+  /** The App Id */
+  sources?: InputMaybe<Array<Scalars["Sources"]>>;
+};
+
+export type ProfileQueryRequest = {
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  /** The handles for the profile */
+  handles?: InputMaybe<Array<Scalars["Handle"]>>;
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+  /** The ethereum addresses */
+  ownedBy?: InputMaybe<Array<Scalars["EthereumAddress"]>>;
+  /** The profile ids */
+  profileIds?: InputMaybe<Array<Scalars["ProfileId"]>>;
+  /** The mirrored publication id */
+  whoMirroredPublicationId?: InputMaybe<Scalars["InternalPublicationId"]>;
+};
+
+/** Profile search results */
+export type ProfileSearchResult = {
+  __typename?: "ProfileSearchResult";
+  items: Array<Profile>;
+  pageInfo: PaginatedResultInfo;
+  type: SearchRequestTypes;
+};
+
+/** profile sort criteria */
+export enum ProfileSortCriteria {
+  CreatedOn = "CREATED_ON",
+  LatestCreated = "LATEST_CREATED",
+  MostCollects = "MOST_COLLECTS",
+  MostComments = "MOST_COMMENTS",
+  MostFollowers = "MOST_FOLLOWERS",
+  MostMirrors = "MOST_MIRRORS",
+  MostPosts = "MOST_POSTS",
+  MostPublication = "MOST_PUBLICATION",
+}
+
+/** The Profile Stats */
+export type ProfileStats = {
+  __typename?: "ProfileStats";
+  commentsTotal: Scalars["Int"];
+  id: Scalars["ProfileId"];
+  mirrorsTotal: Scalars["Int"];
+  postsTotal: Scalars["Int"];
+  publicationsTotal: Scalars["Int"];
+  /** Total collects count */
+  totalCollects: Scalars["Int"];
+  /** Total comment count */
+  totalComments: Scalars["Int"];
+  /** Total follower count */
+  totalFollowers: Scalars["Int"];
+  /** Total following count (remember the wallet follows not profile so will be same for every profile they own) */
+  totalFollowing: Scalars["Int"];
+  /** Total mirror count */
+  totalMirrors: Scalars["Int"];
+  /** Total post count */
+  totalPosts: Scalars["Int"];
+  /** Total publication count */
+  totalPublications: Scalars["Int"];
+};
+
+/** The Profile Stats */
+export type ProfileStatsCommentsTotalArgs = {
+  forSources: Array<Scalars["Sources"]>;
+};
+
+/** The Profile Stats */
+export type ProfileStatsMirrorsTotalArgs = {
+  forSources: Array<Scalars["Sources"]>;
+};
+
+/** The Profile Stats */
+export type ProfileStatsPostsTotalArgs = {
+  forSources: Array<Scalars["Sources"]>;
+};
+
+/** The Profile Stats */
+export type ProfileStatsPublicationsTotalArgs = {
+  forSources: Array<Scalars["Sources"]>;
+};
+
+export type ProxyActionError = {
+  __typename?: "ProxyActionError";
+  lastKnownTxId?: Maybe<Scalars["TxId"]>;
+  reason: Scalars["String"];
+};
+
+export type ProxyActionQueued = {
+  __typename?: "ProxyActionQueued";
+  queuedAt: Scalars["DateTime"];
+};
+
+export type ProxyActionRequest = {
+  collect?: InputMaybe<CollectProxyAction>;
+  follow?: InputMaybe<FollowProxyAction>;
+};
+
+export type ProxyActionStatusResult = {
+  __typename?: "ProxyActionStatusResult";
+  status: ProxyActionStatusTypes;
+  txHash: Scalars["TxHash"];
+  txId: Scalars["TxId"];
+};
+
+export type ProxyActionStatusResultUnion = ProxyActionError | ProxyActionQueued | ProxyActionStatusResult;
+
+/** The proxy action status */
+export enum ProxyActionStatusTypes {
+  Complete = "COMPLETE",
+  Minting = "MINTING",
+  Transferring = "TRANSFERRING",
+}
+
+export type Publication = Comment | Mirror | Post;
+
+/** The publication content warning */
+export enum PublicationContentWarning {
+  Nsfw = "NSFW",
+  Sensitive = "SENSITIVE",
+  Spoiler = "SPOILER",
+}
+
+export type PublicationForSale = Comment | Post;
+
+/** The publication main focus */
+export enum PublicationMainFocus {
+  Article = "ARTICLE",
+  Audio = "AUDIO",
+  Embed = "EMBED",
+  Image = "IMAGE",
+  Link = "LINK",
+  TextOnly = "TEXT_ONLY",
+  Video = "VIDEO",
+}
+
+/** Publication metadata content waring filters */
+export type PublicationMetadataContentWarningFilter = {
+  /** By default all content warnings will be hidden you can include them in your query by adding them to this array. */
+  includeOneOf?: InputMaybe<Array<PublicationContentWarning>>;
+};
+
+/** The publication metadata display types */
+export enum PublicationMetadataDisplayTypes {
+  Date = "date",
+  Number = "number",
+  String = "string",
+}
+
+/** Publication metadata filters */
+export type PublicationMetadataFilters = {
+  contentWarning?: InputMaybe<PublicationMetadataContentWarningFilter>;
+  /** IOS 639-1 language code aka en or it and ISO 3166-1 alpha-2 region code aka US or IT aka en-US or it-IT. You can just filter on language if you wish. */
+  locale?: InputMaybe<Scalars["Locale"]>;
+  mainContentFocus?: InputMaybe<Array<PublicationMainFocus>>;
+  tags?: InputMaybe<PublicationMetadataTagsFilter>;
+};
+
+/** The metadata attribute output */
+export type PublicationMetadataMediaInput = {
+  /** The alt tags for accessibility */
+  altTag?: InputMaybe<Scalars["String"]>;
+  /** The cover for any video or audio you attached */
+  cover?: InputMaybe<Scalars["String"]>;
+  item: Scalars["Url"];
+  /** This is the mime type of media */
+  type?: InputMaybe<Scalars["MimeType"]>;
+};
+
+export type PublicationMetadataStatus = {
+  __typename?: "PublicationMetadataStatus";
+  /** If metadata validation failed it will put a reason why here */
+  reason?: Maybe<Scalars["String"]>;
+  status: PublicationMetadataStatusType;
+};
+
+/** publication metadata status type */
+export enum PublicationMetadataStatusType {
+  MetadataValidationFailed = "METADATA_VALIDATION_FAILED",
+  NotFound = "NOT_FOUND",
+  Pending = "PENDING",
+  Success = "SUCCESS",
+}
+
+/** Publication metadata tag filter */
+export type PublicationMetadataTagsFilter = {
+  /** Needs to only match all */
+  all?: InputMaybe<Array<Scalars["String"]>>;
+  /** Needs to only match one of */
+  oneOf?: InputMaybe<Array<Scalars["String"]>>;
+};
+
+export type PublicationMetadataV1Input = {
+  /**
+   * A URL to a multi-media attachment for the item. The file extensions GLTF, GLB, WEBM, MP4, M4V, OGV,
+   *       and OGG are supported, along with the audio-only extensions MP3, WAV, and OGA.
+   *       Animation_url also supports HTML pages, allowing you to build rich experiences and interactive NFTs using JavaScript canvas,
+   *       WebGL, and more. Scripts and relative paths within the HTML page are now supported. However, access to browser extensions is not supported.
+   */
+  animation_url?: InputMaybe<Scalars["Url"]>;
+  /**  This is the appId the content belongs to */
+  appId?: InputMaybe<Scalars["Sources"]>;
+  /**  These are the attributes for the item, which will show up on the OpenSea and others NFT trading websites on the item. */
+  attributes: Array<MetadataAttributeInput>;
+  /** The content of a publication. If this is blank `media` must be defined or its out of spec */
+  content?: InputMaybe<Scalars["Markdown"]>;
+  /** A human-readable description of the item. */
+  description?: InputMaybe<Scalars["Markdown"]>;
+  /**
+   * This is the URL that will appear below the asset's image on OpenSea and others etc
+   *       and will allow users to leave OpenSea and view the item on the site.
+   */
+  external_url?: InputMaybe<Scalars["Url"]>;
+  /** legacy to support OpenSea will store any NFT image here. */
+  image?: InputMaybe<Scalars["Url"]>;
+  /** This is the mime type of the image. This is used if your uploading more advanced cover images as sometimes ipfs does not emit the content header so this solves that */
+  imageMimeType?: InputMaybe<Scalars["MimeType"]>;
+  /**  This is lens supported attached media items to the publication */
+  media?: InputMaybe<Array<PublicationMetadataMediaInput>>;
+  /** The metadata id can be anything but if your uploading to ipfs you will want it to be random.. using uuid could be an option! */
+  metadata_id: Scalars["String"];
+  /** Name of the item. */
+  name: Scalars["String"];
+  /** Signed metadata to validate the owner */
+  signatureContext?: InputMaybe<PublicationSignatureContextInput>;
+  /** The metadata version. (1.0.0 | 2.0.0) */
+  version: Scalars["String"];
+};
+
+export type PublicationMetadataV2Input = {
+  /**
+   * A URL to a multi-media attachment for the item. The file extensions GLTF, GLB, WEBM, MP4, M4V, OGV,
+   *       and OGG are supported, along with the audio-only extensions MP3, WAV, and OGA.
+   *       Animation_url also supports HTML pages, allowing you to build rich experiences and interactive NFTs using JavaScript canvas,
+   *       WebGL, and more. Scripts and relative paths within the HTML page are now supported. However, access to browser extensions is not supported.
+   */
+  animation_url?: InputMaybe<Scalars["Url"]>;
+  /**  This is the appId the content belongs to */
+  appId?: InputMaybe<Scalars["Sources"]>;
+  /**  These are the attributes for the item, which will show up on the OpenSea and others NFT trading websites on the item. */
+  attributes: Array<MetadataAttributeInput>;
+  /** The content of a publication. If this is blank `media` must be defined or its out of spec */
+  content?: InputMaybe<Scalars["Markdown"]>;
+  /** Ability to add a content warning */
+  contentWarning?: InputMaybe<PublicationContentWarning>;
+  /** A human-readable description of the item. */
+  description?: InputMaybe<Scalars["Markdown"]>;
+  /**
+   * This is the URL that will appear below the asset's image on OpenSea and others etc
+   *       and will allow users to leave OpenSea and view the item on the site.
+   */
+  external_url?: InputMaybe<Scalars["Url"]>;
+  /** legacy to support OpenSea will store any NFT image here. */
+  image?: InputMaybe<Scalars["Url"]>;
+  /** This is the mime type of the image. This is used if your uploading more advanced cover images as sometimes ipfs does not emit the content header so this solves that */
+  imageMimeType?: InputMaybe<Scalars["MimeType"]>;
+  /** IOS 639-1 language code aka en or it and ISO 3166-1 alpha-2 region code aka US or IT aka en-US or it-IT */
+  locale: Scalars["Locale"];
+  /** Main content focus that for this publication */
+  mainContentFocus: PublicationMainFocus;
+  /**  This is lens supported attached media items to the publication */
+  media?: InputMaybe<Array<PublicationMetadataMediaInput>>;
+  /** The metadata id can be anything but if your uploading to ipfs you will want it to be random.. using uuid could be an option! */
+  metadata_id: Scalars["String"];
+  /** Name of the item. */
+  name: Scalars["String"];
+  /** Signed metadata to validate the owner */
+  signatureContext?: InputMaybe<PublicationSignatureContextInput>;
+  /** Ability to tag your publication */
+  tags?: InputMaybe<Array<Scalars["String"]>>;
+  /** The metadata version. (1.0.0 | 2.0.0) */
+  version: Scalars["String"];
+};
+
+export type PublicationQueryRequest = {
+  /** The publication id */
+  publicationId?: InputMaybe<Scalars["InternalPublicationId"]>;
+  /** The tx hash */
+  txHash?: InputMaybe<Scalars["TxHash"]>;
+};
+
+/** Publication reporting fraud subreason */
+export enum PublicationReportingFraudSubreason {
+  Impersonation = "IMPERSONATION",
+  Scam = "SCAM",
+}
+
+/** Publication reporting illegal subreason */
+export enum PublicationReportingIllegalSubreason {
+  AnimalAbuse = "ANIMAL_ABUSE",
+  DirectThreat = "DIRECT_THREAT",
+  HumanAbuse = "HUMAN_ABUSE",
+  ThreatIndividual = "THREAT_INDIVIDUAL",
+  Violence = "VIOLENCE",
+}
+
+/** Publication reporting reason */
+export enum PublicationReportingReason {
+  Fraud = "FRAUD",
+  Illegal = "ILLEGAL",
+  Sensitive = "SENSITIVE",
+  Spam = "SPAM",
+}
+
+/** Publication reporting sensitive subreason */
+export enum PublicationReportingSensitiveSubreason {
+  Nsfw = "NSFW",
+  Offensive = "OFFENSIVE",
+}
+
+/** Publication reporting spam subreason */
+export enum PublicationReportingSpamSubreason {
+  FakeEngagement = "FAKE_ENGAGEMENT",
+  ManipulationAlgo = "MANIPULATION_ALGO",
+  Misleading = "MISLEADING",
+  MisuseHashtags = "MISUSE_HASHTAGS",
+  Repetitive = "REPETITIVE",
+  SomethingElse = "SOMETHING_ELSE",
+  Unrelated = "UNRELATED",
+}
+
+/** The social comment */
+export type PublicationRevenue = {
+  __typename?: "PublicationRevenue";
+  publication: Publication;
+  revenue: RevenueAggregate;
+};
+
+export type PublicationRevenueQueryRequest = {
+  /** The publication id */
+  publicationId: Scalars["InternalPublicationId"];
+};
+
+/** Publication search results */
+export type PublicationSearchResult = {
+  __typename?: "PublicationSearchResult";
+  items: Array<PublicationSearchResultItem>;
+  pageInfo: PaginatedResultInfo;
+  type: SearchRequestTypes;
+};
+
+export type PublicationSearchResultItem = Comment | Post;
+
+export type PublicationSignatureContextInput = {
+  signature: Scalars["String"];
+};
+
+/** Publication sort criteria */
+export enum PublicationSortCriteria {
+  CuratedProfiles = "CURATED_PROFILES",
+  Latest = "LATEST",
+  TopCollected = "TOP_COLLECTED",
+  TopCommented = "TOP_COMMENTED",
+  TopMirrored = "TOP_MIRRORED",
+}
+
+/** The publication stats */
+export type PublicationStats = {
+  __typename?: "PublicationStats";
+  commentsTotal: Scalars["Int"];
+  /** The publication id */
+  id: Scalars["InternalPublicationId"];
+  /** The total amount of collects */
+  totalAmountOfCollects: Scalars["Int"];
+  /** The total amount of comments */
+  totalAmountOfComments: Scalars["Int"];
+  /** The total amount of mirrors */
+  totalAmountOfMirrors: Scalars["Int"];
+  /** The total amount of upvotes */
+  totalDownvotes: Scalars["Int"];
+  /** The total amount of downvotes */
+  totalUpvotes: Scalars["Int"];
+};
+
+/** The publication stats */
+export type PublicationStatsCommentsTotalArgs = {
+  forSources: Array<Scalars["Sources"]>;
+};
+
+/** The publication types */
+export enum PublicationTypes {
+  Comment = "COMMENT",
+  Mirror = "MIRROR",
+  Post = "POST",
+}
+
+export type PublicationValidateMetadataResult = {
+  __typename?: "PublicationValidateMetadataResult";
+  /** If `valid` is false it will put a reason why here */
+  reason?: Maybe<Scalars["String"]>;
+  valid: Scalars["Boolean"];
+};
+
+export type PublicationsQueryRequest = {
+  /** The ethereum address */
+  collectedBy?: InputMaybe<Scalars["EthereumAddress"]>;
+  /** The publication id you wish to get comments for */
+  commentsOf?: InputMaybe<Scalars["InternalPublicationId"]>;
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  customFilters?: InputMaybe<Array<CustomFiltersTypes>>;
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+  metadata?: InputMaybe<PublicationMetadataFilters>;
+  /** Profile id */
+  profileId?: InputMaybe<Scalars["ProfileId"]>;
+  /** Profile ids */
+  profileIds?: InputMaybe<Array<Scalars["ProfileId"]>>;
+  /** The publication id */
+  publicationIds?: InputMaybe<Array<Scalars["InternalPublicationId"]>>;
+  /** The publication types you want to query */
+  publicationTypes?: InputMaybe<Array<PublicationTypes>>;
+  /** The App Id */
+  sources?: InputMaybe<Array<Scalars["Sources"]>>;
+};
+
+export type Query = {
+  __typename?: "Query";
+  allPublicationsTags: PaginatedAllPublicationsTagsResult;
+  approvedModuleAllowanceAmount: Array<ApprovedAllowanceAmount>;
+  challenge: AuthChallengeResult;
+  claimableHandles: ClaimableHandles;
+  claimableStatus: ClaimStatus;
+  defaultProfile?: Maybe<Profile>;
+  doesFollow: Array<DoesFollowResponse>;
+  enabledModuleCurrencies: Array<Erc20>;
+  enabledModules: EnabledModules;
+  exploreProfiles: ExploreProfileResult;
+  explorePublications: ExplorePublicationResult;
+  feed: PaginatedFeedResult;
+  feedHighlights: PaginatedTimelineResult;
+  followerNftOwnedTokenIds?: Maybe<FollowerNftOwnedTokenIds>;
+  followers: PaginatedFollowersResult;
+  following: PaginatedFollowingResult;
+  generateModuleCurrencyApprovalData: GenerateModuleCurrencyApproval;
+  globalProtocolStats: GlobalProtocolStats;
+  hasTxHashBeenIndexed: TransactionResult;
+  internalPublicationFilter: PaginatedPublicationResult;
+  mutualFollowersProfiles: PaginatedProfileResult;
+  nftOwnershipChallenge: NftOwnershipChallengeResult;
+  nfts: NfTsResult;
+  notifications: PaginatedNotificationResult;
+  pendingApprovalFollows: PendingApproveFollowsResult;
+  ping: Scalars["String"];
+  profile?: Maybe<Profile>;
+  profileFollowModuleBeenRedeemed: Scalars["Boolean"];
+  profileFollowRevenue: FollowRevenueResult;
+  profileOnChainIdentity: Array<OnChainIdentity>;
+  profilePublicationRevenue: ProfilePublicationRevenueResult;
+  profilePublicationsForSale: PaginatedProfilePublicationsForSaleResult;
+  profiles: PaginatedProfileResult;
+  proxyActionStatus: ProxyActionStatusResultUnion;
+  publication?: Maybe<Publication>;
+  publicationMetadataStatus: PublicationMetadataStatus;
+  publicationRevenue?: Maybe<PublicationRevenue>;
+  publications: PaginatedPublicationResult;
+  recommendedProfiles: Array<Profile>;
+  rel?: Maybe<Scalars["Void"]>;
+  search: SearchResult;
+  /** @deprecated You should be using feed, this will not be supported after 15th November 2021, please migrate. */
+  timeline: PaginatedTimelineResult;
+  txIdToTxHash: Scalars["TxHash"];
+  unknownEnabledModules: EnabledModules;
+  userSigNonces: UserSigNonces;
+  validatePublicationMetadata: PublicationValidateMetadataResult;
+  verify: Scalars["Boolean"];
+  whoCollectedPublication: PaginatedWhoCollectedResult;
+  whoReactedPublication: PaginatedWhoReactedResult;
+};
+
+export type QueryAllPublicationsTagsArgs = {
+  request: AllPublicationsTagsRequest;
+};
+
+export type QueryApprovedModuleAllowanceAmountArgs = {
+  request: ApprovedModuleAllowanceAmountRequest;
+};
+
+export type QueryChallengeArgs = {
+  request: ChallengeRequest;
+};
+
+export type QueryDefaultProfileArgs = {
+  request: DefaultProfileRequest;
+};
+
+export type QueryDoesFollowArgs = {
+  request: DoesFollowRequest;
+};
+
+export type QueryExploreProfilesArgs = {
+  request: ExploreProfilesRequest;
+};
+
+export type QueryExplorePublicationsArgs = {
+  request: ExplorePublicationRequest;
+};
+
+export type QueryFeedArgs = {
+  request: FeedRequest;
+};
+
+export type QueryFeedHighlightsArgs = {
+  request: FeedHighlightsRequest;
+};
+
+export type QueryFollowerNftOwnedTokenIdsArgs = {
+  request: FollowerNftOwnedTokenIdsRequest;
+};
+
+export type QueryFollowersArgs = {
+  request: FollowersRequest;
+};
+
+export type QueryFollowingArgs = {
+  request: FollowingRequest;
+};
+
+export type QueryGenerateModuleCurrencyApprovalDataArgs = {
+  request: GenerateModuleCurrencyApprovalDataRequest;
+};
+
+export type QueryGlobalProtocolStatsArgs = {
+  request?: InputMaybe<GlobalProtocolStatsRequest>;
+};
+
+export type QueryHasTxHashBeenIndexedArgs = {
+  request: HasTxHashBeenIndexedRequest;
+};
+
+export type QueryInternalPublicationFilterArgs = {
+  request: InternalPublicationsFilterRequest;
+};
+
+export type QueryMutualFollowersProfilesArgs = {
+  request: MutualFollowersProfilesQueryRequest;
+};
+
+export type QueryNftOwnershipChallengeArgs = {
+  request: NftOwnershipChallengeRequest;
+};
+
+export type QueryNftsArgs = {
+  request: NfTsRequest;
+};
+
+export type QueryNotificationsArgs = {
+  request: NotificationRequest;
+};
+
+export type QueryPendingApprovalFollowsArgs = {
+  request: PendingApprovalFollowsRequest;
+};
+
+export type QueryProfileArgs = {
+  request: SingleProfileQueryRequest;
+};
+
+export type QueryProfileFollowModuleBeenRedeemedArgs = {
+  request: ProfileFollowModuleBeenRedeemedRequest;
+};
+
+export type QueryProfileFollowRevenueArgs = {
+  request: ProfileFollowRevenueQueryRequest;
+};
+
+export type QueryProfileOnChainIdentityArgs = {
+  request: ProfileOnChainIdentityRequest;
+};
+
+export type QueryProfilePublicationRevenueArgs = {
+  request: ProfilePublicationRevenueQueryRequest;
+};
+
+export type QueryProfilePublicationsForSaleArgs = {
+  request: ProfilePublicationsForSaleRequest;
+};
+
+export type QueryProfilesArgs = {
+  request: ProfileQueryRequest;
+};
+
+export type QueryProxyActionStatusArgs = {
+  proxyActionId: Scalars["ProxyActionId"];
+};
+
+export type QueryPublicationArgs = {
+  request: PublicationQueryRequest;
+};
+
+export type QueryPublicationMetadataStatusArgs = {
+  request: GetPublicationMetadataStatusRequest;
+};
+
+export type QueryPublicationRevenueArgs = {
+  request: PublicationRevenueQueryRequest;
+};
+
+export type QueryPublicationsArgs = {
+  request: PublicationsQueryRequest;
+};
+
+export type QueryRecommendedProfilesArgs = {
+  options?: InputMaybe<RecommendedProfileOptions>;
+};
+
+export type QueryRelArgs = {
+  request: RelRequest;
+};
+
+export type QuerySearchArgs = {
+  request: SearchQueryRequest;
+};
+
+export type QueryTimelineArgs = {
+  request: TimelineRequest;
+};
+
+export type QueryTxIdToTxHashArgs = {
+  txId: Scalars["TxId"];
+};
+
+export type QueryValidatePublicationMetadataArgs = {
+  request: ValidatePublicationMetadataRequest;
+};
+
+export type QueryVerifyArgs = {
+  request: VerifyRequest;
+};
+
+export type QueryWhoCollectedPublicationArgs = {
+  request: WhoCollectedPublicationRequest;
+};
+
+export type QueryWhoReactedPublicationArgs = {
+  request: WhoReactedPublicationRequest;
+};
+
+export type ReactionEvent = {
+  __typename?: "ReactionEvent";
+  profile: Profile;
+  reaction: ReactionTypes;
+  timestamp: Scalars["DateTime"];
+};
+
+export type ReactionFieldResolverRequest = {
+  /** Profile id */
+  profileId?: InputMaybe<Scalars["ProfileId"]>;
+};
+
+export type ReactionRequest = {
+  /** Profile id to perform the action */
+  profileId: Scalars["ProfileId"];
+  /** The internal publication id */
+  publicationId: Scalars["InternalPublicationId"];
+  /** The reaction */
+  reaction: ReactionTypes;
+};
+
+/** Reaction types */
+export enum ReactionTypes {
+  Downvote = "DOWNVOTE",
+  Upvote = "UPVOTE",
+}
+
+export type RecommendedProfileOptions = {
+  /** If you wish to turn ML off */
+  disableML?: InputMaybe<Scalars["Boolean"]>;
+};
+
+export type ReferenceModule =
+  | DegreesOfSeparationReferenceModuleSettings
+  | FollowOnlyReferenceModuleSettings
+  | UnknownReferenceModuleSettings;
+
+export type ReferenceModuleParams = {
+  /** The degrees of seperation reference module */
+  degreesOfSeparationReferenceModule?: InputMaybe<DegreesOfSeparationReferenceModuleParams>;
+  /** The follower only reference module */
+  followerOnlyReferenceModule?: InputMaybe<Scalars["Boolean"]>;
+  /** A unknown reference module */
+  unknownReferenceModule?: InputMaybe<UnknownReferenceModuleParams>;
+};
+
+/** The reference module types */
+export enum ReferenceModules {
+  DegreesOfSeparationReferenceModule = "DegreesOfSeparationReferenceModule",
+  FollowerOnlyReferenceModule = "FollowerOnlyReferenceModule",
+  UnknownReferenceModule = "UnknownReferenceModule",
+}
+
+/** The refresh request */
+export type RefreshRequest = {
+  /** The refresh token */
+  refreshToken: Scalars["Jwt"];
+};
+
+export type RelRequest = {
+  ethereumAddress: Scalars["EthereumAddress"];
+  secret: Scalars["String"];
+};
+
+export type RelayError = {
+  __typename?: "RelayError";
+  reason: RelayErrorReasons;
+};
+
+/** Relay error reason */
+export enum RelayErrorReasons {
+  Expired = "EXPIRED",
+  HandleTaken = "HANDLE_TAKEN",
+  NotAllowed = "NOT_ALLOWED",
+  Rejected = "REJECTED",
+  WrongWalletSigned = "WRONG_WALLET_SIGNED",
+}
+
+export type RelayResult = RelayError | RelayerResult;
+
+/** The relayer result */
+export type RelayerResult = {
+  __typename?: "RelayerResult";
+  /** The tx hash - you should use the `txId` as your identifier as gas prices can be upgraded meaning txHash will change */
+  txHash: Scalars["TxHash"];
+  /** The tx id */
+  txId: Scalars["TxId"];
+};
+
+export type ReportPublicationRequest = {
+  additionalComments?: InputMaybe<Scalars["String"]>;
+  publicationId: Scalars["InternalPublicationId"];
+  reason: ReportingReasonInputParams;
+};
+
+export type ReportingReasonInputParams = {
+  fraudReason?: InputMaybe<FraudReasonInputParams>;
+  illegalReason?: InputMaybe<IllegalReasonInputParams>;
+  sensitiveReason?: InputMaybe<SensitiveReasonInputParams>;
+  spamReason?: InputMaybe<SpamReasonInputParams>;
+};
+
+export type ReservedClaimableHandle = {
+  __typename?: "ReservedClaimableHandle";
+  expiry: Scalars["DateTime"];
+  handle: Scalars["Handle"];
+  id: Scalars["HandleClaimIdScalar"];
+  source: Scalars["String"];
+};
+
+export type RevenueAggregate = {
+  __typename?: "RevenueAggregate";
+  total: Erc20Amount;
+};
+
+export type RevertCollectModuleSettings = {
+  __typename?: "RevertCollectModuleSettings";
+  contractAddress: Scalars["ContractAddress"];
+  /** The collect modules enum */
+  type: CollectModules;
+};
+
+export type RevertFollowModuleSettings = {
+  __typename?: "RevertFollowModuleSettings";
+  contractAddress: Scalars["ContractAddress"];
+  /** The follow module enum */
+  type: FollowModules;
+};
+
+export type SearchQueryRequest = {
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  customFilters?: InputMaybe<Array<CustomFiltersTypes>>;
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+  /** The search term */
+  query: Scalars["Search"];
+  /** The App Id */
+  sources?: InputMaybe<Array<Scalars["Sources"]>>;
+  type: SearchRequestTypes;
+};
+
+/** Search request types */
+export enum SearchRequestTypes {
+  Profile = "PROFILE",
+  Publication = "PUBLICATION",
+}
+
+export type SearchResult = ProfileSearchResult | PublicationSearchResult;
+
+export type SensitiveReasonInputParams = {
+  reason: PublicationReportingReason;
+  subreason: PublicationReportingSensitiveSubreason;
+};
+
+/** The broadcast item */
+export type SetDefaultProfileBroadcastItemResult = {
+  __typename?: "SetDefaultProfileBroadcastItemResult";
+  /** The date the broadcast item expiries */
+  expiresAt: Scalars["DateTime"];
+  /** This broadcast item ID */
+  id: Scalars["BroadcastId"];
+  /** The typed data */
+  typedData: SetDefaultProfileEip712TypedData;
+};
+
+/** The default profile eip 712 typed data */
+export type SetDefaultProfileEip712TypedData = {
+  __typename?: "SetDefaultProfileEIP712TypedData";
+  /** The typed data domain */
+  domain: Eip712TypedDataDomain;
+  /** The types */
+  types: SetDefaultProfileEip712TypedDataTypes;
+  /** The values */
+  value: SetDefaultProfileEip712TypedDataValue;
+};
+
+/** The default profile eip 712 typed data types */
+export type SetDefaultProfileEip712TypedDataTypes = {
+  __typename?: "SetDefaultProfileEIP712TypedDataTypes";
+  SetDefaultProfileWithSig: Array<Eip712TypedDataField>;
+};
+
+/** The default profile eip 712 typed data value */
+export type SetDefaultProfileEip712TypedDataValue = {
+  __typename?: "SetDefaultProfileEIP712TypedDataValue";
+  deadline: Scalars["UnixTimestamp"];
+  nonce: Scalars["Nonce"];
+  profileId: Scalars["ProfileId"];
+  wallet: Scalars["EthereumAddress"];
+};
+
+export type SetDispatcherRequest = {
+  /** The dispatcher address - they can post, comment, mirror, set follow module, change your profile picture on your behalf, if left as none it will use the built in dispatcher address. */
+  dispatcher?: InputMaybe<Scalars["EthereumAddress"]>;
+  /** If you want to enable or disable it */
+  enable?: InputMaybe<Scalars["Boolean"]>;
+  /** The profile id */
+  profileId: Scalars["ProfileId"];
+};
+
+/** The signed auth challenge */
+export type SignedAuthChallenge = {
+  /** The ethereum address you signed the signature with */
+  address: Scalars["EthereumAddress"];
+  /** The signature */
+  signature: Scalars["Signature"];
+};
+
+export type SingleProfileQueryRequest = {
+  /** The handle for the profile */
+  handle?: InputMaybe<Scalars["Handle"]>;
+  /** The profile id */
+  profileId?: InputMaybe<Scalars["ProfileId"]>;
+};
+
+export type SpamReasonInputParams = {
+  reason: PublicationReportingReason;
+  subreason: PublicationReportingSpamSubreason;
+};
+
+export type SybilDotOrgIdentity = {
+  __typename?: "SybilDotOrgIdentity";
+  source: SybilDotOrgIdentitySource;
+  /** The sybil dot org status */
+  verified: Scalars["Boolean"];
+};
+
+export type SybilDotOrgIdentitySource = {
+  __typename?: "SybilDotOrgIdentitySource";
+  twitter: SybilDotOrgTwitterIdentity;
+};
+
+export type SybilDotOrgTwitterIdentity = {
+  __typename?: "SybilDotOrgTwitterIdentity";
+  handle?: Maybe<Scalars["String"]>;
+};
+
+/** The social comment */
+export type TagResult = {
+  __typename?: "TagResult";
+  /** The tag */
+  tag: Scalars["PublicationTag"];
+  /** The total amount of publication tagged */
+  total: Scalars["Int"];
+};
+
+/** The publications tags sort criteria */
+export enum TagSortCriteria {
+  Alphabetical = "ALPHABETICAL",
+  MostPopular = "MOST_POPULAR",
+}
+
+export type TimedFeeCollectModuleParams = {
+  /** The collect module amount info */
+  amount: ModuleFeeAmountParams;
+  /** Follower only */
+  followerOnly: Scalars["Boolean"];
+  /** The collect module recipient address */
+  recipient: Scalars["EthereumAddress"];
+  /** The collect module referral fee */
+  referralFee: Scalars["Float"];
+};
+
+export type TimedFeeCollectModuleSettings = {
+  __typename?: "TimedFeeCollectModuleSettings";
+  /** The collect module amount info */
+  amount: ModuleFeeAmount;
+  contractAddress: Scalars["ContractAddress"];
+  /** The collect module end timestamp */
+  endTimestamp: Scalars["DateTime"];
+  /** Follower only */
+  followerOnly: Scalars["Boolean"];
+  /** The collect module recipient address */
+  recipient: Scalars["EthereumAddress"];
+  /** The collect module referral fee */
+  referralFee: Scalars["Float"];
+  /** The collect modules enum */
+  type: CollectModules;
+};
+
+export type TimelineRequest = {
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+  metadata?: InputMaybe<PublicationMetadataFilters>;
+  /** The profile id */
+  profileId: Scalars["ProfileId"];
+  /** The App Id */
+  sources?: InputMaybe<Array<Scalars["Sources"]>>;
+  /** The timeline types you wish to include, if nothing passed in will bring back all */
+  timelineTypes?: InputMaybe<Array<TimelineType>>;
+};
+
+/** Timeline types */
+export enum TimelineType {
+  CollectComment = "COLLECT_COMMENT",
+  CollectPost = "COLLECT_POST",
+  Comment = "COMMENT",
+  Mirror = "MIRROR",
+  Post = "POST",
+}
+
+export type TransactionError = {
+  __typename?: "TransactionError";
+  reason: TransactionErrorReasons;
+  txReceipt?: Maybe<TransactionReceipt>;
+};
+
+/** Transaction error reason */
+export enum TransactionErrorReasons {
+  Reverted = "REVERTED",
+}
+
+export type TransactionIndexedResult = {
+  __typename?: "TransactionIndexedResult";
+  indexed: Scalars["Boolean"];
+  /** Publications can be indexed but the ipfs link for example not findable for x time. This allows you to work that out for publications. If its not a publication tx then it always be null. */
+  metadataStatus?: Maybe<PublicationMetadataStatus>;
+  txHash: Scalars["TxHash"];
+  txReceipt?: Maybe<TransactionReceipt>;
+};
+
+export type TransactionReceipt = {
+  __typename?: "TransactionReceipt";
+  blockHash: Scalars["String"];
+  blockNumber: Scalars["Int"];
+  byzantium: Scalars["Boolean"];
+  confirmations: Scalars["Int"];
+  contractAddress?: Maybe<Scalars["ContractAddress"]>;
+  cumulativeGasUsed: Scalars["String"];
+  effectiveGasPrice: Scalars["String"];
+  from: Scalars["EthereumAddress"];
+  gasUsed: Scalars["String"];
+  logs: Array<Log>;
+  logsBloom: Scalars["String"];
+  root?: Maybe<Scalars["String"]>;
+  status?: Maybe<Scalars["Int"]>;
+  to?: Maybe<Scalars["EthereumAddress"]>;
+  transactionHash: Scalars["TxHash"];
+  transactionIndex: Scalars["Int"];
+  type: Scalars["Int"];
+};
+
+export type TransactionResult = TransactionError | TransactionIndexedResult;
+
+export type TypedDataOptions = {
+  /** If you wish to override the nonce for the sig if you want to do some clever stuff in the client */
+  overrideSigNonce: Scalars["Nonce"];
+};
+
+export type UnfollowRequest = {
+  profile: Scalars["ProfileId"];
+};
+
+export type UnknownCollectModuleParams = {
+  contractAddress: Scalars["ContractAddress"];
+  /** The encoded data to submit with the module */
+  data: Scalars["BlockchainData"];
+};
+
+export type UnknownCollectModuleSettings = {
+  __typename?: "UnknownCollectModuleSettings";
+  /** The data used to setup the module which you can decode with your known ABI  */
+  collectModuleReturnData: Scalars["CollectModuleData"];
+  contractAddress: Scalars["ContractAddress"];
+  /** The collect modules enum */
+  type: CollectModules;
+};
+
+export type UnknownFollowModuleParams = {
+  contractAddress: Scalars["ContractAddress"];
+  /** The encoded data to submit with the module */
+  data: Scalars["BlockchainData"];
+};
+
+export type UnknownFollowModuleRedeemParams = {
+  /** The encoded data to submit with the module */
+  data: Scalars["BlockchainData"];
+};
+
+export type UnknownFollowModuleSettings = {
+  __typename?: "UnknownFollowModuleSettings";
+  contractAddress: Scalars["ContractAddress"];
+  /** The data used to setup the module which you can decode with your known ABI  */
+  followModuleReturnData: Scalars["FollowModuleData"];
+  /** The follow modules enum */
+  type: FollowModules;
+};
+
+export type UnknownReferenceModuleParams = {
+  contractAddress: Scalars["ContractAddress"];
+  /** The encoded data to submit with the module */
+  data: Scalars["BlockchainData"];
+};
+
+export type UnknownReferenceModuleSettings = {
+  __typename?: "UnknownReferenceModuleSettings";
+  contractAddress: Scalars["ContractAddress"];
+  /** The data used to setup the module which you can decode with your known ABI  */
+  referenceModuleReturnData: Scalars["ReferenceModuleData"];
+  /** The reference modules enum */
+  type: ReferenceModules;
+};
+
+export type UpdateProfileImageRequest = {
+  /** The nft data */
+  nftData?: InputMaybe<NftData>;
+  profileId: Scalars["ProfileId"];
+  /** The url to the image if offline */
+  url?: InputMaybe<Scalars["Url"]>;
+};
+
+export type UserSigNonces = {
+  __typename?: "UserSigNonces";
+  lensHubOnChainSigNonce: Scalars["Nonce"];
+  peripheryOnChainSigNonce: Scalars["Nonce"];
+};
+
+export type ValidatePublicationMetadataRequest = {
+  metadatav1?: InputMaybe<PublicationMetadataV1Input>;
+  metadatav2?: InputMaybe<PublicationMetadataV2Input>;
+};
+
+/** The access request */
+export type VerifyRequest = {
+  /** The access token */
+  accessToken: Scalars["Jwt"];
+};
+
+export type Wallet = {
+  __typename?: "Wallet";
+  address: Scalars["EthereumAddress"];
+  /** The default profile for the wallet for now it is just their first profile, this will be the default profile they picked soon enough */
+  defaultProfile?: Maybe<Profile>;
+};
+
+export type WhoCollectedPublicationRequest = {
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+  /** Internal publication id */
+  publicationId: Scalars["InternalPublicationId"];
+};
+
+export type WhoReactedPublicationRequest = {
+  cursor?: InputMaybe<Scalars["Cursor"]>;
+  limit?: InputMaybe<Scalars["LimitScalar"]>;
+  /** Internal publication id */
+  publicationId: Scalars["InternalPublicationId"];
+};
+
+/** The Profile */
+export type WhoReactedResult = {
+  __typename?: "WhoReactedResult";
+  profile: Profile;
+  /** The reaction */
+  reaction: ReactionTypes;
+  /** The reaction */
+  reactionAt: Scalars["DateTime"];
+  /** The reaction id */
+  reactionId: Scalars["ReactionId"];
+};
+
+export type WorldcoinIdentity = {
+  __typename?: "WorldcoinIdentity";
+  /** If the profile has verified as a user */
+  isHuman: Scalars["Boolean"];
+};
+
+export type MediaFieldsFragment = {
+  __typename?: "Media";
+  url: any;
+  width?: number | null;
+  height?: number | null;
+  mimeType?: any | null;
+};
+
+export type ProfileFieldsFragment = {
+  __typename?: "Profile";
+  id: any;
+  name?: string | null;
+  bio?: string | null;
+  isFollowedByMe: boolean;
+  isFollowing: boolean;
+  followNftAddress?: any | null;
+  metadata?: any | null;
+  isDefault: boolean;
+  handle: any;
+  ownedBy: any;
+  attributes?: Array<{
+    __typename?: "Attribute";
+    displayType?: string | null;
+    traitType?: string | null;
+    key: string;
+    value: string;
+  }> | null;
+  picture?:
+    | {
+        __typename?: "MediaSet";
+        original: {
+          __typename?: "Media";
+          url: any;
+          width?: number | null;
+          height?: number | null;
+          mimeType?: any | null;
+        };
+        small?: {
+          __typename?: "Media";
+          url: any;
+          width?: number | null;
+          height?: number | null;
+          mimeType?: any | null;
+        } | null;
+        medium?: {
+          __typename?: "Media";
+          url: any;
+          width?: number | null;
+          height?: number | null;
+          mimeType?: any | null;
+        } | null;
+      }
+    | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+    | null;
+  coverPicture?:
+    | {
+        __typename?: "MediaSet";
+        original: {
+          __typename?: "Media";
+          url: any;
+          width?: number | null;
+          height?: number | null;
+          mimeType?: any | null;
+        };
+        small?: {
+          __typename?: "Media";
+          url: any;
+          width?: number | null;
+          height?: number | null;
+          mimeType?: any | null;
+        } | null;
+        medium?: {
+          __typename?: "Media";
+          url: any;
+          width?: number | null;
+          height?: number | null;
+          mimeType?: any | null;
+        } | null;
+      }
+    | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+    | null;
+  dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+  stats: {
+    __typename?: "ProfileStats";
+    totalFollowers: number;
+    totalFollowing: number;
+    totalPosts: number;
+    totalComments: number;
+    totalMirrors: number;
+    totalPublications: number;
+    totalCollects: number;
+  };
+  followModule?:
+    | {
+        __typename?: "FeeFollowModuleSettings";
+        type: FollowModules;
+        recipient: any;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+    | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+    | { __typename?: "UnknownFollowModuleSettings" }
+    | null;
+};
+
+export type PublicationStatsFieldsFragment = {
+  __typename?: "PublicationStats";
+  totalAmountOfMirrors: number;
+  totalAmountOfCollects: number;
+  totalAmountOfComments: number;
+};
+
+export type MetadataOutputFieldsFragment = {
+  __typename?: "MetadataOutput";
+  name?: string | null;
+  description?: any | null;
+  content?: any | null;
+  media: Array<{
+    __typename?: "MediaSet";
+    original: { __typename?: "Media"; url: any; width?: number | null; height?: number | null; mimeType?: any | null };
+    small?: {
+      __typename?: "Media";
+      url: any;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: any | null;
+    } | null;
+    medium?: {
+      __typename?: "Media";
+      url: any;
+      width?: number | null;
+      height?: number | null;
+      mimeType?: any | null;
+    } | null;
+  }>;
+  attributes: Array<{
+    __typename?: "MetadataAttributeOutput";
+    displayType?: PublicationMetadataDisplayTypes | null;
+    traitType?: string | null;
+    value?: string | null;
+  }>;
+};
+
+export type Erc20FieldsFragment = {
+  __typename?: "Erc20";
+  name: string;
+  symbol: string;
+  decimals: number;
+  address: any;
+};
+
+type CollectModuleFields_FeeCollectModuleSettings_Fragment = {
+  __typename: "FeeCollectModuleSettings";
+  type: CollectModules;
+  recipient: any;
+  referralFee: number;
+  amount: {
+    __typename?: "ModuleFeeAmount";
+    value: string;
+    asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+  };
+};
+
+type CollectModuleFields_FreeCollectModuleSettings_Fragment = {
+  __typename: "FreeCollectModuleSettings";
+  type: CollectModules;
+  followerOnly: boolean;
+  contractAddress: any;
+};
+
+type CollectModuleFields_LimitedFeeCollectModuleSettings_Fragment = {
+  __typename: "LimitedFeeCollectModuleSettings";
+  type: CollectModules;
+  collectLimit: string;
+  recipient: any;
+  referralFee: number;
+  amount: {
+    __typename?: "ModuleFeeAmount";
+    value: string;
+    asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+  };
+};
+
+type CollectModuleFields_LimitedTimedFeeCollectModuleSettings_Fragment = {
+  __typename: "LimitedTimedFeeCollectModuleSettings";
+  type: CollectModules;
+  collectLimit: string;
+  recipient: any;
+  referralFee: number;
+  endTimestamp: any;
+  amount: {
+    __typename?: "ModuleFeeAmount";
+    value: string;
+    asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+  };
+};
+
+type CollectModuleFields_RevertCollectModuleSettings_Fragment = {
+  __typename: "RevertCollectModuleSettings";
+  type: CollectModules;
+};
+
+type CollectModuleFields_TimedFeeCollectModuleSettings_Fragment = {
+  __typename: "TimedFeeCollectModuleSettings";
+  type: CollectModules;
+  recipient: any;
+  referralFee: number;
+  endTimestamp: any;
+  amount: {
+    __typename?: "ModuleFeeAmount";
+    value: string;
+    asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+  };
+};
+
+type CollectModuleFields_UnknownCollectModuleSettings_Fragment = { __typename: "UnknownCollectModuleSettings" };
+
+export type CollectModuleFieldsFragment =
+  | CollectModuleFields_FeeCollectModuleSettings_Fragment
+  | CollectModuleFields_FreeCollectModuleSettings_Fragment
+  | CollectModuleFields_LimitedFeeCollectModuleSettings_Fragment
+  | CollectModuleFields_LimitedTimedFeeCollectModuleSettings_Fragment
+  | CollectModuleFields_RevertCollectModuleSettings_Fragment
+  | CollectModuleFields_TimedFeeCollectModuleSettings_Fragment
+  | CollectModuleFields_UnknownCollectModuleSettings_Fragment;
+
+export type PostFieldsFragment = {
+  __typename?: "Post";
+  id: any;
+  createdAt: any;
+  appId?: any | null;
+  hidden: boolean;
+  reaction?: ReactionTypes | null;
+  mirrors: Array<any>;
+  hasCollectedByMe: boolean;
+  profile: {
+    __typename?: "Profile";
+    id: any;
+    name?: string | null;
+    bio?: string | null;
+    isFollowedByMe: boolean;
+    isFollowing: boolean;
+    followNftAddress?: any | null;
+    metadata?: any | null;
+    isDefault: boolean;
+    handle: any;
+    ownedBy: any;
+    attributes?: Array<{
+      __typename?: "Attribute";
+      displayType?: string | null;
+      traitType?: string | null;
+      key: string;
+      value: string;
+    }> | null;
+    picture?:
+      | {
+          __typename?: "MediaSet";
+          original: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          };
+          small?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+          medium?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+        }
+      | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+      | null;
+    coverPicture?:
+      | {
+          __typename?: "MediaSet";
+          original: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          };
+          small?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+          medium?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+        }
+      | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+      | null;
+    dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+    stats: {
+      __typename?: "ProfileStats";
+      totalFollowers: number;
+      totalFollowing: number;
+      totalPosts: number;
+      totalComments: number;
+      totalMirrors: number;
+      totalPublications: number;
+      totalCollects: number;
+    };
+    followModule?:
+      | {
+          __typename?: "FeeFollowModuleSettings";
+          type: FollowModules;
+          recipient: any;
+          amount: {
+            __typename?: "ModuleFeeAmount";
+            value: string;
+            asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+          };
+        }
+      | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+      | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+      | { __typename?: "UnknownFollowModuleSettings" }
+      | null;
+  };
+  stats: {
+    __typename?: "PublicationStats";
+    totalAmountOfMirrors: number;
+    totalAmountOfCollects: number;
+    totalAmountOfComments: number;
+  };
+  metadata: {
+    __typename?: "MetadataOutput";
+    name?: string | null;
+    description?: any | null;
+    content?: any | null;
+    media: Array<{
+      __typename?: "MediaSet";
+      original: {
+        __typename?: "Media";
+        url: any;
+        width?: number | null;
+        height?: number | null;
+        mimeType?: any | null;
+      };
+      small?: {
+        __typename?: "Media";
+        url: any;
+        width?: number | null;
+        height?: number | null;
+        mimeType?: any | null;
+      } | null;
+      medium?: {
+        __typename?: "Media";
+        url: any;
+        width?: number | null;
+        height?: number | null;
+        mimeType?: any | null;
+      } | null;
+    }>;
+    attributes: Array<{
+      __typename?: "MetadataAttributeOutput";
+      displayType?: PublicationMetadataDisplayTypes | null;
+      traitType?: string | null;
+      value?: string | null;
+    }>;
+  };
+  collectModule:
+    | {
+        __typename: "FeeCollectModuleSettings";
+        type: CollectModules;
+        recipient: any;
+        referralFee: number;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | { __typename: "FreeCollectModuleSettings"; type: CollectModules; followerOnly: boolean; contractAddress: any }
+    | {
+        __typename: "LimitedFeeCollectModuleSettings";
+        type: CollectModules;
+        collectLimit: string;
+        recipient: any;
+        referralFee: number;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | {
+        __typename: "LimitedTimedFeeCollectModuleSettings";
+        type: CollectModules;
+        collectLimit: string;
+        recipient: any;
+        referralFee: number;
+        endTimestamp: any;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+    | {
+        __typename: "TimedFeeCollectModuleSettings";
+        type: CollectModules;
+        recipient: any;
+        referralFee: number;
+        endTimestamp: any;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | { __typename: "UnknownCollectModuleSettings" };
+  referenceModule?:
+    | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+    | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+    | { __typename?: "UnknownReferenceModuleSettings" }
+    | null;
+};
+
+export type MirrorBaseFieldsFragment = {
+  __typename?: "Mirror";
+  id: any;
+  createdAt: any;
+  appId?: any | null;
+  hidden: boolean;
+  reaction?: ReactionTypes | null;
+  hasCollectedByMe: boolean;
+  profile: {
+    __typename?: "Profile";
+    id: any;
+    name?: string | null;
+    bio?: string | null;
+    isFollowedByMe: boolean;
+    isFollowing: boolean;
+    followNftAddress?: any | null;
+    metadata?: any | null;
+    isDefault: boolean;
+    handle: any;
+    ownedBy: any;
+    attributes?: Array<{
+      __typename?: "Attribute";
+      displayType?: string | null;
+      traitType?: string | null;
+      key: string;
+      value: string;
+    }> | null;
+    picture?:
+      | {
+          __typename?: "MediaSet";
+          original: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          };
+          small?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+          medium?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+        }
+      | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+      | null;
+    coverPicture?:
+      | {
+          __typename?: "MediaSet";
+          original: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          };
+          small?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+          medium?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+        }
+      | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+      | null;
+    dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+    stats: {
+      __typename?: "ProfileStats";
+      totalFollowers: number;
+      totalFollowing: number;
+      totalPosts: number;
+      totalComments: number;
+      totalMirrors: number;
+      totalPublications: number;
+      totalCollects: number;
+    };
+    followModule?:
+      | {
+          __typename?: "FeeFollowModuleSettings";
+          type: FollowModules;
+          recipient: any;
+          amount: {
+            __typename?: "ModuleFeeAmount";
+            value: string;
+            asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+          };
+        }
+      | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+      | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+      | { __typename?: "UnknownFollowModuleSettings" }
+      | null;
+  };
+  stats: {
+    __typename?: "PublicationStats";
+    totalAmountOfMirrors: number;
+    totalAmountOfCollects: number;
+    totalAmountOfComments: number;
+  };
+  metadata: {
+    __typename?: "MetadataOutput";
+    name?: string | null;
+    description?: any | null;
+    content?: any | null;
+    media: Array<{
+      __typename?: "MediaSet";
+      original: {
+        __typename?: "Media";
+        url: any;
+        width?: number | null;
+        height?: number | null;
+        mimeType?: any | null;
+      };
+      small?: {
+        __typename?: "Media";
+        url: any;
+        width?: number | null;
+        height?: number | null;
+        mimeType?: any | null;
+      } | null;
+      medium?: {
+        __typename?: "Media";
+        url: any;
+        width?: number | null;
+        height?: number | null;
+        mimeType?: any | null;
+      } | null;
+    }>;
+    attributes: Array<{
+      __typename?: "MetadataAttributeOutput";
+      displayType?: PublicationMetadataDisplayTypes | null;
+      traitType?: string | null;
+      value?: string | null;
+    }>;
+  };
+  collectModule:
+    | {
+        __typename: "FeeCollectModuleSettings";
+        type: CollectModules;
+        recipient: any;
+        referralFee: number;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | { __typename: "FreeCollectModuleSettings"; type: CollectModules; followerOnly: boolean; contractAddress: any }
+    | {
+        __typename: "LimitedFeeCollectModuleSettings";
+        type: CollectModules;
+        collectLimit: string;
+        recipient: any;
+        referralFee: number;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | {
+        __typename: "LimitedTimedFeeCollectModuleSettings";
+        type: CollectModules;
+        collectLimit: string;
+        recipient: any;
+        referralFee: number;
+        endTimestamp: any;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+    | {
+        __typename: "TimedFeeCollectModuleSettings";
+        type: CollectModules;
+        recipient: any;
+        referralFee: number;
+        endTimestamp: any;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | { __typename: "UnknownCollectModuleSettings" };
+  referenceModule?:
+    | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+    | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+    | { __typename?: "UnknownReferenceModuleSettings" }
+    | null;
+};
+
+export type MirrorFieldsFragment = {
+  __typename?: "Mirror";
+  id: any;
+  createdAt: any;
+  appId?: any | null;
+  hidden: boolean;
+  reaction?: ReactionTypes | null;
+  hasCollectedByMe: boolean;
+  mirrorOf:
+    | {
+        __typename?: "Comment";
+        id: any;
+        createdAt: any;
+        appId?: any | null;
+        hidden: boolean;
+        reaction?: ReactionTypes | null;
+        mirrors: Array<any>;
+        hasCollectedByMe: boolean;
+        mainPost:
+          | {
+              __typename?: "Mirror";
+              id: any;
+              createdAt: any;
+              appId?: any | null;
+              hidden: boolean;
+              reaction?: ReactionTypes | null;
+              hasCollectedByMe: boolean;
+              mirrorOf:
+                | {
+                    __typename?: "Comment";
+                    id: any;
+                    createdAt: any;
+                    appId?: any | null;
+                    hidden: boolean;
+                    reaction?: ReactionTypes | null;
+                    mirrors: Array<any>;
+                    hasCollectedByMe: boolean;
+                    mainPost:
+                      | {
+                          __typename?: "Mirror";
+                          id: any;
+                          createdAt: any;
+                          appId?: any | null;
+                          hidden: boolean;
+                          reaction?: ReactionTypes | null;
+                          hasCollectedByMe: boolean;
+                          profile: {
+                            __typename?: "Profile";
+                            id: any;
+                            name?: string | null;
+                            bio?: string | null;
+                            isFollowedByMe: boolean;
+                            isFollowing: boolean;
+                            followNftAddress?: any | null;
+                            metadata?: any | null;
+                            isDefault: boolean;
+                            handle: any;
+                            ownedBy: any;
+                            attributes?: Array<{
+                              __typename?: "Attribute";
+                              displayType?: string | null;
+                              traitType?: string | null;
+                              key: string;
+                              value: string;
+                            }> | null;
+                            picture?:
+                              | {
+                                  __typename?: "MediaSet";
+                                  original: {
+                                    __typename?: "Media";
+                                    url: any;
+                                    width?: number | null;
+                                    height?: number | null;
+                                    mimeType?: any | null;
+                                  };
+                                  small?: {
+                                    __typename?: "Media";
+                                    url: any;
+                                    width?: number | null;
+                                    height?: number | null;
+                                    mimeType?: any | null;
+                                  } | null;
+                                  medium?: {
+                                    __typename?: "Media";
+                                    url: any;
+                                    width?: number | null;
+                                    height?: number | null;
+                                    mimeType?: any | null;
+                                  } | null;
+                                }
+                              | {
+                                  __typename?: "NftImage";
+                                  contractAddress: any;
+                                  tokenId: string;
+                                  uri: any;
+                                  verified: boolean;
+                                }
+                              | null;
+                            coverPicture?:
+                              | {
+                                  __typename?: "MediaSet";
+                                  original: {
+                                    __typename?: "Media";
+                                    url: any;
+                                    width?: number | null;
+                                    height?: number | null;
+                                    mimeType?: any | null;
+                                  };
+                                  small?: {
+                                    __typename?: "Media";
+                                    url: any;
+                                    width?: number | null;
+                                    height?: number | null;
+                                    mimeType?: any | null;
+                                  } | null;
+                                  medium?: {
+                                    __typename?: "Media";
+                                    url: any;
+                                    width?: number | null;
+                                    height?: number | null;
+                                    mimeType?: any | null;
+                                  } | null;
+                                }
+                              | {
+                                  __typename?: "NftImage";
+                                  contractAddress: any;
+                                  tokenId: string;
+                                  uri: any;
+                                  verified: boolean;
+                                }
+                              | null;
+                            dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+                            stats: {
+                              __typename?: "ProfileStats";
+                              totalFollowers: number;
+                              totalFollowing: number;
+                              totalPosts: number;
+                              totalComments: number;
+                              totalMirrors: number;
+                              totalPublications: number;
+                              totalCollects: number;
+                            };
+                            followModule?:
+                              | {
+                                  __typename?: "FeeFollowModuleSettings";
+                                  type: FollowModules;
+                                  recipient: any;
+                                  amount: {
+                                    __typename?: "ModuleFeeAmount";
+                                    value: string;
+                                    asset: {
+                                      __typename?: "Erc20";
+                                      name: string;
+                                      symbol: string;
+                                      decimals: number;
+                                      address: any;
+                                    };
+                                  };
+                                }
+                              | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+                              | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+                              | { __typename?: "UnknownFollowModuleSettings" }
+                              | null;
+                          };
+                          stats: {
+                            __typename?: "PublicationStats";
+                            totalAmountOfMirrors: number;
+                            totalAmountOfCollects: number;
+                            totalAmountOfComments: number;
+                          };
+                          metadata: {
+                            __typename?: "MetadataOutput";
+                            name?: string | null;
+                            description?: any | null;
+                            content?: any | null;
+                            media: Array<{
+                              __typename?: "MediaSet";
+                              original: {
+                                __typename?: "Media";
+                                url: any;
+                                width?: number | null;
+                                height?: number | null;
+                                mimeType?: any | null;
+                              };
+                              small?: {
+                                __typename?: "Media";
+                                url: any;
+                                width?: number | null;
+                                height?: number | null;
+                                mimeType?: any | null;
+                              } | null;
+                              medium?: {
+                                __typename?: "Media";
+                                url: any;
+                                width?: number | null;
+                                height?: number | null;
+                                mimeType?: any | null;
+                              } | null;
+                            }>;
+                            attributes: Array<{
+                              __typename?: "MetadataAttributeOutput";
+                              displayType?: PublicationMetadataDisplayTypes | null;
+                              traitType?: string | null;
+                              value?: string | null;
+                            }>;
+                          };
+                          collectModule:
+                            | {
+                                __typename: "FeeCollectModuleSettings";
+                                type: CollectModules;
+                                recipient: any;
+                                referralFee: number;
+                                amount: {
+                                  __typename?: "ModuleFeeAmount";
+                                  value: string;
+                                  asset: {
+                                    __typename?: "Erc20";
+                                    name: string;
+                                    symbol: string;
+                                    decimals: number;
+                                    address: any;
+                                  };
+                                };
+                              }
+                            | {
+                                __typename: "FreeCollectModuleSettings";
+                                type: CollectModules;
+                                followerOnly: boolean;
+                                contractAddress: any;
+                              }
+                            | {
+                                __typename: "LimitedFeeCollectModuleSettings";
+                                type: CollectModules;
+                                collectLimit: string;
+                                recipient: any;
+                                referralFee: number;
+                                amount: {
+                                  __typename?: "ModuleFeeAmount";
+                                  value: string;
+                                  asset: {
+                                    __typename?: "Erc20";
+                                    name: string;
+                                    symbol: string;
+                                    decimals: number;
+                                    address: any;
+                                  };
+                                };
+                              }
+                            | {
+                                __typename: "LimitedTimedFeeCollectModuleSettings";
+                                type: CollectModules;
+                                collectLimit: string;
+                                recipient: any;
+                                referralFee: number;
+                                endTimestamp: any;
+                                amount: {
+                                  __typename?: "ModuleFeeAmount";
+                                  value: string;
+                                  asset: {
+                                    __typename?: "Erc20";
+                                    name: string;
+                                    symbol: string;
+                                    decimals: number;
+                                    address: any;
+                                  };
+                                };
+                              }
+                            | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+                            | {
+                                __typename: "TimedFeeCollectModuleSettings";
+                                type: CollectModules;
+                                recipient: any;
+                                referralFee: number;
+                                endTimestamp: any;
+                                amount: {
+                                  __typename?: "ModuleFeeAmount";
+                                  value: string;
+                                  asset: {
+                                    __typename?: "Erc20";
+                                    name: string;
+                                    symbol: string;
+                                    decimals: number;
+                                    address: any;
+                                  };
+                                };
+                              }
+                            | { __typename: "UnknownCollectModuleSettings" };
+                          referenceModule?:
+                            | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+                            | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+                            | { __typename?: "UnknownReferenceModuleSettings" }
+                            | null;
+                        }
+                      | {
+                          __typename?: "Post";
+                          id: any;
+                          createdAt: any;
+                          appId?: any | null;
+                          hidden: boolean;
+                          reaction?: ReactionTypes | null;
+                          mirrors: Array<any>;
+                          hasCollectedByMe: boolean;
+                          profile: {
+                            __typename?: "Profile";
+                            id: any;
+                            name?: string | null;
+                            bio?: string | null;
+                            isFollowedByMe: boolean;
+                            isFollowing: boolean;
+                            followNftAddress?: any | null;
+                            metadata?: any | null;
+                            isDefault: boolean;
+                            handle: any;
+                            ownedBy: any;
+                            attributes?: Array<{
+                              __typename?: "Attribute";
+                              displayType?: string | null;
+                              traitType?: string | null;
+                              key: string;
+                              value: string;
+                            }> | null;
+                            picture?:
+                              | {
+                                  __typename?: "MediaSet";
+                                  original: {
+                                    __typename?: "Media";
+                                    url: any;
+                                    width?: number | null;
+                                    height?: number | null;
+                                    mimeType?: any | null;
+                                  };
+                                  small?: {
+                                    __typename?: "Media";
+                                    url: any;
+                                    width?: number | null;
+                                    height?: number | null;
+                                    mimeType?: any | null;
+                                  } | null;
+                                  medium?: {
+                                    __typename?: "Media";
+                                    url: any;
+                                    width?: number | null;
+                                    height?: number | null;
+                                    mimeType?: any | null;
+                                  } | null;
+                                }
+                              | {
+                                  __typename?: "NftImage";
+                                  contractAddress: any;
+                                  tokenId: string;
+                                  uri: any;
+                                  verified: boolean;
+                                }
+                              | null;
+                            coverPicture?:
+                              | {
+                                  __typename?: "MediaSet";
+                                  original: {
+                                    __typename?: "Media";
+                                    url: any;
+                                    width?: number | null;
+                                    height?: number | null;
+                                    mimeType?: any | null;
+                                  };
+                                  small?: {
+                                    __typename?: "Media";
+                                    url: any;
+                                    width?: number | null;
+                                    height?: number | null;
+                                    mimeType?: any | null;
+                                  } | null;
+                                  medium?: {
+                                    __typename?: "Media";
+                                    url: any;
+                                    width?: number | null;
+                                    height?: number | null;
+                                    mimeType?: any | null;
+                                  } | null;
+                                }
+                              | {
+                                  __typename?: "NftImage";
+                                  contractAddress: any;
+                                  tokenId: string;
+                                  uri: any;
+                                  verified: boolean;
+                                }
+                              | null;
+                            dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+                            stats: {
+                              __typename?: "ProfileStats";
+                              totalFollowers: number;
+                              totalFollowing: number;
+                              totalPosts: number;
+                              totalComments: number;
+                              totalMirrors: number;
+                              totalPublications: number;
+                              totalCollects: number;
+                            };
+                            followModule?:
+                              | {
+                                  __typename?: "FeeFollowModuleSettings";
+                                  type: FollowModules;
+                                  recipient: any;
+                                  amount: {
+                                    __typename?: "ModuleFeeAmount";
+                                    value: string;
+                                    asset: {
+                                      __typename?: "Erc20";
+                                      name: string;
+                                      symbol: string;
+                                      decimals: number;
+                                      address: any;
+                                    };
+                                  };
+                                }
+                              | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+                              | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+                              | { __typename?: "UnknownFollowModuleSettings" }
+                              | null;
+                          };
+                          stats: {
+                            __typename?: "PublicationStats";
+                            totalAmountOfMirrors: number;
+                            totalAmountOfCollects: number;
+                            totalAmountOfComments: number;
+                          };
+                          metadata: {
+                            __typename?: "MetadataOutput";
+                            name?: string | null;
+                            description?: any | null;
+                            content?: any | null;
+                            media: Array<{
+                              __typename?: "MediaSet";
+                              original: {
+                                __typename?: "Media";
+                                url: any;
+                                width?: number | null;
+                                height?: number | null;
+                                mimeType?: any | null;
+                              };
+                              small?: {
+                                __typename?: "Media";
+                                url: any;
+                                width?: number | null;
+                                height?: number | null;
+                                mimeType?: any | null;
+                              } | null;
+                              medium?: {
+                                __typename?: "Media";
+                                url: any;
+                                width?: number | null;
+                                height?: number | null;
+                                mimeType?: any | null;
+                              } | null;
+                            }>;
+                            attributes: Array<{
+                              __typename?: "MetadataAttributeOutput";
+                              displayType?: PublicationMetadataDisplayTypes | null;
+                              traitType?: string | null;
+                              value?: string | null;
+                            }>;
+                          };
+                          collectModule:
+                            | {
+                                __typename: "FeeCollectModuleSettings";
+                                type: CollectModules;
+                                recipient: any;
+                                referralFee: number;
+                                amount: {
+                                  __typename?: "ModuleFeeAmount";
+                                  value: string;
+                                  asset: {
+                                    __typename?: "Erc20";
+                                    name: string;
+                                    symbol: string;
+                                    decimals: number;
+                                    address: any;
+                                  };
+                                };
+                              }
+                            | {
+                                __typename: "FreeCollectModuleSettings";
+                                type: CollectModules;
+                                followerOnly: boolean;
+                                contractAddress: any;
+                              }
+                            | {
+                                __typename: "LimitedFeeCollectModuleSettings";
+                                type: CollectModules;
+                                collectLimit: string;
+                                recipient: any;
+                                referralFee: number;
+                                amount: {
+                                  __typename?: "ModuleFeeAmount";
+                                  value: string;
+                                  asset: {
+                                    __typename?: "Erc20";
+                                    name: string;
+                                    symbol: string;
+                                    decimals: number;
+                                    address: any;
+                                  };
+                                };
+                              }
+                            | {
+                                __typename: "LimitedTimedFeeCollectModuleSettings";
+                                type: CollectModules;
+                                collectLimit: string;
+                                recipient: any;
+                                referralFee: number;
+                                endTimestamp: any;
+                                amount: {
+                                  __typename?: "ModuleFeeAmount";
+                                  value: string;
+                                  asset: {
+                                    __typename?: "Erc20";
+                                    name: string;
+                                    symbol: string;
+                                    decimals: number;
+                                    address: any;
+                                  };
+                                };
+                              }
+                            | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+                            | {
+                                __typename: "TimedFeeCollectModuleSettings";
+                                type: CollectModules;
+                                recipient: any;
+                                referralFee: number;
+                                endTimestamp: any;
+                                amount: {
+                                  __typename?: "ModuleFeeAmount";
+                                  value: string;
+                                  asset: {
+                                    __typename?: "Erc20";
+                                    name: string;
+                                    symbol: string;
+                                    decimals: number;
+                                    address: any;
+                                  };
+                                };
+                              }
+                            | { __typename: "UnknownCollectModuleSettings" };
+                          referenceModule?:
+                            | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+                            | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+                            | { __typename?: "UnknownReferenceModuleSettings" }
+                            | null;
+                        };
+                    profile: {
+                      __typename?: "Profile";
+                      id: any;
+                      name?: string | null;
+                      bio?: string | null;
+                      isFollowedByMe: boolean;
+                      isFollowing: boolean;
+                      followNftAddress?: any | null;
+                      metadata?: any | null;
+                      isDefault: boolean;
+                      handle: any;
+                      ownedBy: any;
+                      attributes?: Array<{
+                        __typename?: "Attribute";
+                        displayType?: string | null;
+                        traitType?: string | null;
+                        key: string;
+                        value: string;
+                      }> | null;
+                      picture?:
+                        | {
+                            __typename?: "MediaSet";
+                            original: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            };
+                            small?: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            } | null;
+                            medium?: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            } | null;
+                          }
+                        | {
+                            __typename?: "NftImage";
+                            contractAddress: any;
+                            tokenId: string;
+                            uri: any;
+                            verified: boolean;
+                          }
+                        | null;
+                      coverPicture?:
+                        | {
+                            __typename?: "MediaSet";
+                            original: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            };
+                            small?: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            } | null;
+                            medium?: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            } | null;
+                          }
+                        | {
+                            __typename?: "NftImage";
+                            contractAddress: any;
+                            tokenId: string;
+                            uri: any;
+                            verified: boolean;
+                          }
+                        | null;
+                      dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+                      stats: {
+                        __typename?: "ProfileStats";
+                        totalFollowers: number;
+                        totalFollowing: number;
+                        totalPosts: number;
+                        totalComments: number;
+                        totalMirrors: number;
+                        totalPublications: number;
+                        totalCollects: number;
+                      };
+                      followModule?:
+                        | {
+                            __typename?: "FeeFollowModuleSettings";
+                            type: FollowModules;
+                            recipient: any;
+                            amount: {
+                              __typename?: "ModuleFeeAmount";
+                              value: string;
+                              asset: {
+                                __typename?: "Erc20";
+                                name: string;
+                                symbol: string;
+                                decimals: number;
+                                address: any;
+                              };
+                            };
+                          }
+                        | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+                        | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+                        | { __typename?: "UnknownFollowModuleSettings" }
+                        | null;
+                    };
+                    stats: {
+                      __typename?: "PublicationStats";
+                      totalAmountOfMirrors: number;
+                      totalAmountOfCollects: number;
+                      totalAmountOfComments: number;
+                    };
+                    metadata: {
+                      __typename?: "MetadataOutput";
+                      name?: string | null;
+                      description?: any | null;
+                      content?: any | null;
+                      media: Array<{
+                        __typename?: "MediaSet";
+                        original: {
+                          __typename?: "Media";
+                          url: any;
+                          width?: number | null;
+                          height?: number | null;
+                          mimeType?: any | null;
+                        };
+                        small?: {
+                          __typename?: "Media";
+                          url: any;
+                          width?: number | null;
+                          height?: number | null;
+                          mimeType?: any | null;
+                        } | null;
+                        medium?: {
+                          __typename?: "Media";
+                          url: any;
+                          width?: number | null;
+                          height?: number | null;
+                          mimeType?: any | null;
+                        } | null;
+                      }>;
+                      attributes: Array<{
+                        __typename?: "MetadataAttributeOutput";
+                        displayType?: PublicationMetadataDisplayTypes | null;
+                        traitType?: string | null;
+                        value?: string | null;
+                      }>;
+                    };
+                    collectModule:
+                      | {
+                          __typename: "FeeCollectModuleSettings";
+                          type: CollectModules;
+                          recipient: any;
+                          referralFee: number;
+                          amount: {
+                            __typename?: "ModuleFeeAmount";
+                            value: string;
+                            asset: {
+                              __typename?: "Erc20";
+                              name: string;
+                              symbol: string;
+                              decimals: number;
+                              address: any;
+                            };
+                          };
+                        }
+                      | {
+                          __typename: "FreeCollectModuleSettings";
+                          type: CollectModules;
+                          followerOnly: boolean;
+                          contractAddress: any;
+                        }
+                      | {
+                          __typename: "LimitedFeeCollectModuleSettings";
+                          type: CollectModules;
+                          collectLimit: string;
+                          recipient: any;
+                          referralFee: number;
+                          amount: {
+                            __typename?: "ModuleFeeAmount";
+                            value: string;
+                            asset: {
+                              __typename?: "Erc20";
+                              name: string;
+                              symbol: string;
+                              decimals: number;
+                              address: any;
+                            };
+                          };
+                        }
+                      | {
+                          __typename: "LimitedTimedFeeCollectModuleSettings";
+                          type: CollectModules;
+                          collectLimit: string;
+                          recipient: any;
+                          referralFee: number;
+                          endTimestamp: any;
+                          amount: {
+                            __typename?: "ModuleFeeAmount";
+                            value: string;
+                            asset: {
+                              __typename?: "Erc20";
+                              name: string;
+                              symbol: string;
+                              decimals: number;
+                              address: any;
+                            };
+                          };
+                        }
+                      | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+                      | {
+                          __typename: "TimedFeeCollectModuleSettings";
+                          type: CollectModules;
+                          recipient: any;
+                          referralFee: number;
+                          endTimestamp: any;
+                          amount: {
+                            __typename?: "ModuleFeeAmount";
+                            value: string;
+                            asset: {
+                              __typename?: "Erc20";
+                              name: string;
+                              symbol: string;
+                              decimals: number;
+                              address: any;
+                            };
+                          };
+                        }
+                      | { __typename: "UnknownCollectModuleSettings" };
+                    referenceModule?:
+                      | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+                      | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+                      | { __typename?: "UnknownReferenceModuleSettings" }
+                      | null;
+                  }
+                | {
+                    __typename?: "Post";
+                    id: any;
+                    createdAt: any;
+                    appId?: any | null;
+                    hidden: boolean;
+                    reaction?: ReactionTypes | null;
+                    mirrors: Array<any>;
+                    hasCollectedByMe: boolean;
+                    profile: {
+                      __typename?: "Profile";
+                      id: any;
+                      name?: string | null;
+                      bio?: string | null;
+                      isFollowedByMe: boolean;
+                      isFollowing: boolean;
+                      followNftAddress?: any | null;
+                      metadata?: any | null;
+                      isDefault: boolean;
+                      handle: any;
+                      ownedBy: any;
+                      attributes?: Array<{
+                        __typename?: "Attribute";
+                        displayType?: string | null;
+                        traitType?: string | null;
+                        key: string;
+                        value: string;
+                      }> | null;
+                      picture?:
+                        | {
+                            __typename?: "MediaSet";
+                            original: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            };
+                            small?: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            } | null;
+                            medium?: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            } | null;
+                          }
+                        | {
+                            __typename?: "NftImage";
+                            contractAddress: any;
+                            tokenId: string;
+                            uri: any;
+                            verified: boolean;
+                          }
+                        | null;
+                      coverPicture?:
+                        | {
+                            __typename?: "MediaSet";
+                            original: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            };
+                            small?: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            } | null;
+                            medium?: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            } | null;
+                          }
+                        | {
+                            __typename?: "NftImage";
+                            contractAddress: any;
+                            tokenId: string;
+                            uri: any;
+                            verified: boolean;
+                          }
+                        | null;
+                      dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+                      stats: {
+                        __typename?: "ProfileStats";
+                        totalFollowers: number;
+                        totalFollowing: number;
+                        totalPosts: number;
+                        totalComments: number;
+                        totalMirrors: number;
+                        totalPublications: number;
+                        totalCollects: number;
+                      };
+                      followModule?:
+                        | {
+                            __typename?: "FeeFollowModuleSettings";
+                            type: FollowModules;
+                            recipient: any;
+                            amount: {
+                              __typename?: "ModuleFeeAmount";
+                              value: string;
+                              asset: {
+                                __typename?: "Erc20";
+                                name: string;
+                                symbol: string;
+                                decimals: number;
+                                address: any;
+                              };
+                            };
+                          }
+                        | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+                        | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+                        | { __typename?: "UnknownFollowModuleSettings" }
+                        | null;
+                    };
+                    stats: {
+                      __typename?: "PublicationStats";
+                      totalAmountOfMirrors: number;
+                      totalAmountOfCollects: number;
+                      totalAmountOfComments: number;
+                    };
+                    metadata: {
+                      __typename?: "MetadataOutput";
+                      name?: string | null;
+                      description?: any | null;
+                      content?: any | null;
+                      media: Array<{
+                        __typename?: "MediaSet";
+                        original: {
+                          __typename?: "Media";
+                          url: any;
+                          width?: number | null;
+                          height?: number | null;
+                          mimeType?: any | null;
+                        };
+                        small?: {
+                          __typename?: "Media";
+                          url: any;
+                          width?: number | null;
+                          height?: number | null;
+                          mimeType?: any | null;
+                        } | null;
+                        medium?: {
+                          __typename?: "Media";
+                          url: any;
+                          width?: number | null;
+                          height?: number | null;
+                          mimeType?: any | null;
+                        } | null;
+                      }>;
+                      attributes: Array<{
+                        __typename?: "MetadataAttributeOutput";
+                        displayType?: PublicationMetadataDisplayTypes | null;
+                        traitType?: string | null;
+                        value?: string | null;
+                      }>;
+                    };
+                    collectModule:
+                      | {
+                          __typename: "FeeCollectModuleSettings";
+                          type: CollectModules;
+                          recipient: any;
+                          referralFee: number;
+                          amount: {
+                            __typename?: "ModuleFeeAmount";
+                            value: string;
+                            asset: {
+                              __typename?: "Erc20";
+                              name: string;
+                              symbol: string;
+                              decimals: number;
+                              address: any;
+                            };
+                          };
+                        }
+                      | {
+                          __typename: "FreeCollectModuleSettings";
+                          type: CollectModules;
+                          followerOnly: boolean;
+                          contractAddress: any;
+                        }
+                      | {
+                          __typename: "LimitedFeeCollectModuleSettings";
+                          type: CollectModules;
+                          collectLimit: string;
+                          recipient: any;
+                          referralFee: number;
+                          amount: {
+                            __typename?: "ModuleFeeAmount";
+                            value: string;
+                            asset: {
+                              __typename?: "Erc20";
+                              name: string;
+                              symbol: string;
+                              decimals: number;
+                              address: any;
+                            };
+                          };
+                        }
+                      | {
+                          __typename: "LimitedTimedFeeCollectModuleSettings";
+                          type: CollectModules;
+                          collectLimit: string;
+                          recipient: any;
+                          referralFee: number;
+                          endTimestamp: any;
+                          amount: {
+                            __typename?: "ModuleFeeAmount";
+                            value: string;
+                            asset: {
+                              __typename?: "Erc20";
+                              name: string;
+                              symbol: string;
+                              decimals: number;
+                              address: any;
+                            };
+                          };
+                        }
+                      | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+                      | {
+                          __typename: "TimedFeeCollectModuleSettings";
+                          type: CollectModules;
+                          recipient: any;
+                          referralFee: number;
+                          endTimestamp: any;
+                          amount: {
+                            __typename?: "ModuleFeeAmount";
+                            value: string;
+                            asset: {
+                              __typename?: "Erc20";
+                              name: string;
+                              symbol: string;
+                              decimals: number;
+                              address: any;
+                            };
+                          };
+                        }
+                      | { __typename: "UnknownCollectModuleSettings" };
+                    referenceModule?:
+                      | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+                      | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+                      | { __typename?: "UnknownReferenceModuleSettings" }
+                      | null;
+                  };
+              profile: {
+                __typename?: "Profile";
+                id: any;
+                name?: string | null;
+                bio?: string | null;
+                isFollowedByMe: boolean;
+                isFollowing: boolean;
+                followNftAddress?: any | null;
+                metadata?: any | null;
+                isDefault: boolean;
+                handle: any;
+                ownedBy: any;
+                attributes?: Array<{
+                  __typename?: "Attribute";
+                  displayType?: string | null;
+                  traitType?: string | null;
+                  key: string;
+                  value: string;
+                }> | null;
+                picture?:
+                  | {
+                      __typename?: "MediaSet";
+                      original: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      };
+                      small?: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      } | null;
+                      medium?: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      } | null;
+                    }
+                  | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+                  | null;
+                coverPicture?:
+                  | {
+                      __typename?: "MediaSet";
+                      original: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      };
+                      small?: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      } | null;
+                      medium?: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      } | null;
+                    }
+                  | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+                  | null;
+                dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+                stats: {
+                  __typename?: "ProfileStats";
+                  totalFollowers: number;
+                  totalFollowing: number;
+                  totalPosts: number;
+                  totalComments: number;
+                  totalMirrors: number;
+                  totalPublications: number;
+                  totalCollects: number;
+                };
+                followModule?:
+                  | {
+                      __typename?: "FeeFollowModuleSettings";
+                      type: FollowModules;
+                      recipient: any;
+                      amount: {
+                        __typename?: "ModuleFeeAmount";
+                        value: string;
+                        asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                      };
+                    }
+                  | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+                  | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+                  | { __typename?: "UnknownFollowModuleSettings" }
+                  | null;
+              };
+              stats: {
+                __typename?: "PublicationStats";
+                totalAmountOfMirrors: number;
+                totalAmountOfCollects: number;
+                totalAmountOfComments: number;
+              };
+              metadata: {
+                __typename?: "MetadataOutput";
+                name?: string | null;
+                description?: any | null;
+                content?: any | null;
+                media: Array<{
+                  __typename?: "MediaSet";
+                  original: {
+                    __typename?: "Media";
+                    url: any;
+                    width?: number | null;
+                    height?: number | null;
+                    mimeType?: any | null;
+                  };
+                  small?: {
+                    __typename?: "Media";
+                    url: any;
+                    width?: number | null;
+                    height?: number | null;
+                    mimeType?: any | null;
+                  } | null;
+                  medium?: {
+                    __typename?: "Media";
+                    url: any;
+                    width?: number | null;
+                    height?: number | null;
+                    mimeType?: any | null;
+                  } | null;
+                }>;
+                attributes: Array<{
+                  __typename?: "MetadataAttributeOutput";
+                  displayType?: PublicationMetadataDisplayTypes | null;
+                  traitType?: string | null;
+                  value?: string | null;
+                }>;
+              };
+              collectModule:
+                | {
+                    __typename: "FeeCollectModuleSettings";
+                    type: CollectModules;
+                    recipient: any;
+                    referralFee: number;
+                    amount: {
+                      __typename?: "ModuleFeeAmount";
+                      value: string;
+                      asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                    };
+                  }
+                | {
+                    __typename: "FreeCollectModuleSettings";
+                    type: CollectModules;
+                    followerOnly: boolean;
+                    contractAddress: any;
+                  }
+                | {
+                    __typename: "LimitedFeeCollectModuleSettings";
+                    type: CollectModules;
+                    collectLimit: string;
+                    recipient: any;
+                    referralFee: number;
+                    amount: {
+                      __typename?: "ModuleFeeAmount";
+                      value: string;
+                      asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                    };
+                  }
+                | {
+                    __typename: "LimitedTimedFeeCollectModuleSettings";
+                    type: CollectModules;
+                    collectLimit: string;
+                    recipient: any;
+                    referralFee: number;
+                    endTimestamp: any;
+                    amount: {
+                      __typename?: "ModuleFeeAmount";
+                      value: string;
+                      asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                    };
+                  }
+                | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+                | {
+                    __typename: "TimedFeeCollectModuleSettings";
+                    type: CollectModules;
+                    recipient: any;
+                    referralFee: number;
+                    endTimestamp: any;
+                    amount: {
+                      __typename?: "ModuleFeeAmount";
+                      value: string;
+                      asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                    };
+                  }
+                | { __typename: "UnknownCollectModuleSettings" };
+              referenceModule?:
+                | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+                | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+                | { __typename?: "UnknownReferenceModuleSettings" }
+                | null;
+            }
+          | {
+              __typename?: "Post";
+              id: any;
+              createdAt: any;
+              appId?: any | null;
+              hidden: boolean;
+              reaction?: ReactionTypes | null;
+              mirrors: Array<any>;
+              hasCollectedByMe: boolean;
+              profile: {
+                __typename?: "Profile";
+                id: any;
+                name?: string | null;
+                bio?: string | null;
+                isFollowedByMe: boolean;
+                isFollowing: boolean;
+                followNftAddress?: any | null;
+                metadata?: any | null;
+                isDefault: boolean;
+                handle: any;
+                ownedBy: any;
+                attributes?: Array<{
+                  __typename?: "Attribute";
+                  displayType?: string | null;
+                  traitType?: string | null;
+                  key: string;
+                  value: string;
+                }> | null;
+                picture?:
+                  | {
+                      __typename?: "MediaSet";
+                      original: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      };
+                      small?: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      } | null;
+                      medium?: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      } | null;
+                    }
+                  | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+                  | null;
+                coverPicture?:
+                  | {
+                      __typename?: "MediaSet";
+                      original: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      };
+                      small?: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      } | null;
+                      medium?: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      } | null;
+                    }
+                  | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+                  | null;
+                dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+                stats: {
+                  __typename?: "ProfileStats";
+                  totalFollowers: number;
+                  totalFollowing: number;
+                  totalPosts: number;
+                  totalComments: number;
+                  totalMirrors: number;
+                  totalPublications: number;
+                  totalCollects: number;
+                };
+                followModule?:
+                  | {
+                      __typename?: "FeeFollowModuleSettings";
+                      type: FollowModules;
+                      recipient: any;
+                      amount: {
+                        __typename?: "ModuleFeeAmount";
+                        value: string;
+                        asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                      };
+                    }
+                  | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+                  | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+                  | { __typename?: "UnknownFollowModuleSettings" }
+                  | null;
+              };
+              stats: {
+                __typename?: "PublicationStats";
+                totalAmountOfMirrors: number;
+                totalAmountOfCollects: number;
+                totalAmountOfComments: number;
+              };
+              metadata: {
+                __typename?: "MetadataOutput";
+                name?: string | null;
+                description?: any | null;
+                content?: any | null;
+                media: Array<{
+                  __typename?: "MediaSet";
+                  original: {
+                    __typename?: "Media";
+                    url: any;
+                    width?: number | null;
+                    height?: number | null;
+                    mimeType?: any | null;
+                  };
+                  small?: {
+                    __typename?: "Media";
+                    url: any;
+                    width?: number | null;
+                    height?: number | null;
+                    mimeType?: any | null;
+                  } | null;
+                  medium?: {
+                    __typename?: "Media";
+                    url: any;
+                    width?: number | null;
+                    height?: number | null;
+                    mimeType?: any | null;
+                  } | null;
+                }>;
+                attributes: Array<{
+                  __typename?: "MetadataAttributeOutput";
+                  displayType?: PublicationMetadataDisplayTypes | null;
+                  traitType?: string | null;
+                  value?: string | null;
+                }>;
+              };
+              collectModule:
+                | {
+                    __typename: "FeeCollectModuleSettings";
+                    type: CollectModules;
+                    recipient: any;
+                    referralFee: number;
+                    amount: {
+                      __typename?: "ModuleFeeAmount";
+                      value: string;
+                      asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                    };
+                  }
+                | {
+                    __typename: "FreeCollectModuleSettings";
+                    type: CollectModules;
+                    followerOnly: boolean;
+                    contractAddress: any;
+                  }
+                | {
+                    __typename: "LimitedFeeCollectModuleSettings";
+                    type: CollectModules;
+                    collectLimit: string;
+                    recipient: any;
+                    referralFee: number;
+                    amount: {
+                      __typename?: "ModuleFeeAmount";
+                      value: string;
+                      asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                    };
+                  }
+                | {
+                    __typename: "LimitedTimedFeeCollectModuleSettings";
+                    type: CollectModules;
+                    collectLimit: string;
+                    recipient: any;
+                    referralFee: number;
+                    endTimestamp: any;
+                    amount: {
+                      __typename?: "ModuleFeeAmount";
+                      value: string;
+                      asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                    };
+                  }
+                | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+                | {
+                    __typename: "TimedFeeCollectModuleSettings";
+                    type: CollectModules;
+                    recipient: any;
+                    referralFee: number;
+                    endTimestamp: any;
+                    amount: {
+                      __typename?: "ModuleFeeAmount";
+                      value: string;
+                      asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                    };
+                  }
+                | { __typename: "UnknownCollectModuleSettings" };
+              referenceModule?:
+                | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+                | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+                | { __typename?: "UnknownReferenceModuleSettings" }
+                | null;
+            };
+        profile: {
+          __typename?: "Profile";
+          id: any;
+          name?: string | null;
+          bio?: string | null;
+          isFollowedByMe: boolean;
+          isFollowing: boolean;
+          followNftAddress?: any | null;
+          metadata?: any | null;
+          isDefault: boolean;
+          handle: any;
+          ownedBy: any;
+          attributes?: Array<{
+            __typename?: "Attribute";
+            displayType?: string | null;
+            traitType?: string | null;
+            key: string;
+            value: string;
+          }> | null;
+          picture?:
+            | {
+                __typename?: "MediaSet";
+                original: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                };
+                small?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+                medium?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+              }
+            | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+            | null;
+          coverPicture?:
+            | {
+                __typename?: "MediaSet";
+                original: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                };
+                small?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+                medium?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+              }
+            | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+            | null;
+          dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+          stats: {
+            __typename?: "ProfileStats";
+            totalFollowers: number;
+            totalFollowing: number;
+            totalPosts: number;
+            totalComments: number;
+            totalMirrors: number;
+            totalPublications: number;
+            totalCollects: number;
+          };
+          followModule?:
+            | {
+                __typename?: "FeeFollowModuleSettings";
+                type: FollowModules;
+                recipient: any;
+                amount: {
+                  __typename?: "ModuleFeeAmount";
+                  value: string;
+                  asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                };
+              }
+            | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+            | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+            | { __typename?: "UnknownFollowModuleSettings" }
+            | null;
+        };
+        stats: {
+          __typename?: "PublicationStats";
+          totalAmountOfMirrors: number;
+          totalAmountOfCollects: number;
+          totalAmountOfComments: number;
+        };
+        metadata: {
+          __typename?: "MetadataOutput";
+          name?: string | null;
+          description?: any | null;
+          content?: any | null;
+          media: Array<{
+            __typename?: "MediaSet";
+            original: {
+              __typename?: "Media";
+              url: any;
+              width?: number | null;
+              height?: number | null;
+              mimeType?: any | null;
+            };
+            small?: {
+              __typename?: "Media";
+              url: any;
+              width?: number | null;
+              height?: number | null;
+              mimeType?: any | null;
+            } | null;
+            medium?: {
+              __typename?: "Media";
+              url: any;
+              width?: number | null;
+              height?: number | null;
+              mimeType?: any | null;
+            } | null;
+          }>;
+          attributes: Array<{
+            __typename?: "MetadataAttributeOutput";
+            displayType?: PublicationMetadataDisplayTypes | null;
+            traitType?: string | null;
+            value?: string | null;
+          }>;
+        };
+        collectModule:
+          | {
+              __typename: "FeeCollectModuleSettings";
+              type: CollectModules;
+              recipient: any;
+              referralFee: number;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | {
+              __typename: "FreeCollectModuleSettings";
+              type: CollectModules;
+              followerOnly: boolean;
+              contractAddress: any;
+            }
+          | {
+              __typename: "LimitedFeeCollectModuleSettings";
+              type: CollectModules;
+              collectLimit: string;
+              recipient: any;
+              referralFee: number;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | {
+              __typename: "LimitedTimedFeeCollectModuleSettings";
+              type: CollectModules;
+              collectLimit: string;
+              recipient: any;
+              referralFee: number;
+              endTimestamp: any;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+          | {
+              __typename: "TimedFeeCollectModuleSettings";
+              type: CollectModules;
+              recipient: any;
+              referralFee: number;
+              endTimestamp: any;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | { __typename: "UnknownCollectModuleSettings" };
+        referenceModule?:
+          | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+          | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+          | { __typename?: "UnknownReferenceModuleSettings" }
+          | null;
+      }
+    | {
+        __typename?: "Post";
+        id: any;
+        createdAt: any;
+        appId?: any | null;
+        hidden: boolean;
+        reaction?: ReactionTypes | null;
+        mirrors: Array<any>;
+        hasCollectedByMe: boolean;
+        profile: {
+          __typename?: "Profile";
+          id: any;
+          name?: string | null;
+          bio?: string | null;
+          isFollowedByMe: boolean;
+          isFollowing: boolean;
+          followNftAddress?: any | null;
+          metadata?: any | null;
+          isDefault: boolean;
+          handle: any;
+          ownedBy: any;
+          attributes?: Array<{
+            __typename?: "Attribute";
+            displayType?: string | null;
+            traitType?: string | null;
+            key: string;
+            value: string;
+          }> | null;
+          picture?:
+            | {
+                __typename?: "MediaSet";
+                original: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                };
+                small?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+                medium?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+              }
+            | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+            | null;
+          coverPicture?:
+            | {
+                __typename?: "MediaSet";
+                original: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                };
+                small?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+                medium?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+              }
+            | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+            | null;
+          dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+          stats: {
+            __typename?: "ProfileStats";
+            totalFollowers: number;
+            totalFollowing: number;
+            totalPosts: number;
+            totalComments: number;
+            totalMirrors: number;
+            totalPublications: number;
+            totalCollects: number;
+          };
+          followModule?:
+            | {
+                __typename?: "FeeFollowModuleSettings";
+                type: FollowModules;
+                recipient: any;
+                amount: {
+                  __typename?: "ModuleFeeAmount";
+                  value: string;
+                  asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                };
+              }
+            | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+            | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+            | { __typename?: "UnknownFollowModuleSettings" }
+            | null;
+        };
+        stats: {
+          __typename?: "PublicationStats";
+          totalAmountOfMirrors: number;
+          totalAmountOfCollects: number;
+          totalAmountOfComments: number;
+        };
+        metadata: {
+          __typename?: "MetadataOutput";
+          name?: string | null;
+          description?: any | null;
+          content?: any | null;
+          media: Array<{
+            __typename?: "MediaSet";
+            original: {
+              __typename?: "Media";
+              url: any;
+              width?: number | null;
+              height?: number | null;
+              mimeType?: any | null;
+            };
+            small?: {
+              __typename?: "Media";
+              url: any;
+              width?: number | null;
+              height?: number | null;
+              mimeType?: any | null;
+            } | null;
+            medium?: {
+              __typename?: "Media";
+              url: any;
+              width?: number | null;
+              height?: number | null;
+              mimeType?: any | null;
+            } | null;
+          }>;
+          attributes: Array<{
+            __typename?: "MetadataAttributeOutput";
+            displayType?: PublicationMetadataDisplayTypes | null;
+            traitType?: string | null;
+            value?: string | null;
+          }>;
+        };
+        collectModule:
+          | {
+              __typename: "FeeCollectModuleSettings";
+              type: CollectModules;
+              recipient: any;
+              referralFee: number;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | {
+              __typename: "FreeCollectModuleSettings";
+              type: CollectModules;
+              followerOnly: boolean;
+              contractAddress: any;
+            }
+          | {
+              __typename: "LimitedFeeCollectModuleSettings";
+              type: CollectModules;
+              collectLimit: string;
+              recipient: any;
+              referralFee: number;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | {
+              __typename: "LimitedTimedFeeCollectModuleSettings";
+              type: CollectModules;
+              collectLimit: string;
+              recipient: any;
+              referralFee: number;
+              endTimestamp: any;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+          | {
+              __typename: "TimedFeeCollectModuleSettings";
+              type: CollectModules;
+              recipient: any;
+              referralFee: number;
+              endTimestamp: any;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | { __typename: "UnknownCollectModuleSettings" };
+        referenceModule?:
+          | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+          | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+          | { __typename?: "UnknownReferenceModuleSettings" }
+          | null;
+      };
+  profile: {
+    __typename?: "Profile";
+    id: any;
+    name?: string | null;
+    bio?: string | null;
+    isFollowedByMe: boolean;
+    isFollowing: boolean;
+    followNftAddress?: any | null;
+    metadata?: any | null;
+    isDefault: boolean;
+    handle: any;
+    ownedBy: any;
+    attributes?: Array<{
+      __typename?: "Attribute";
+      displayType?: string | null;
+      traitType?: string | null;
+      key: string;
+      value: string;
+    }> | null;
+    picture?:
+      | {
+          __typename?: "MediaSet";
+          original: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          };
+          small?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+          medium?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+        }
+      | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+      | null;
+    coverPicture?:
+      | {
+          __typename?: "MediaSet";
+          original: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          };
+          small?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+          medium?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+        }
+      | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+      | null;
+    dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+    stats: {
+      __typename?: "ProfileStats";
+      totalFollowers: number;
+      totalFollowing: number;
+      totalPosts: number;
+      totalComments: number;
+      totalMirrors: number;
+      totalPublications: number;
+      totalCollects: number;
+    };
+    followModule?:
+      | {
+          __typename?: "FeeFollowModuleSettings";
+          type: FollowModules;
+          recipient: any;
+          amount: {
+            __typename?: "ModuleFeeAmount";
+            value: string;
+            asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+          };
+        }
+      | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+      | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+      | { __typename?: "UnknownFollowModuleSettings" }
+      | null;
+  };
+  stats: {
+    __typename?: "PublicationStats";
+    totalAmountOfMirrors: number;
+    totalAmountOfCollects: number;
+    totalAmountOfComments: number;
+  };
+  metadata: {
+    __typename?: "MetadataOutput";
+    name?: string | null;
+    description?: any | null;
+    content?: any | null;
+    media: Array<{
+      __typename?: "MediaSet";
+      original: {
+        __typename?: "Media";
+        url: any;
+        width?: number | null;
+        height?: number | null;
+        mimeType?: any | null;
+      };
+      small?: {
+        __typename?: "Media";
+        url: any;
+        width?: number | null;
+        height?: number | null;
+        mimeType?: any | null;
+      } | null;
+      medium?: {
+        __typename?: "Media";
+        url: any;
+        width?: number | null;
+        height?: number | null;
+        mimeType?: any | null;
+      } | null;
+    }>;
+    attributes: Array<{
+      __typename?: "MetadataAttributeOutput";
+      displayType?: PublicationMetadataDisplayTypes | null;
+      traitType?: string | null;
+      value?: string | null;
+    }>;
+  };
+  collectModule:
+    | {
+        __typename: "FeeCollectModuleSettings";
+        type: CollectModules;
+        recipient: any;
+        referralFee: number;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | { __typename: "FreeCollectModuleSettings"; type: CollectModules; followerOnly: boolean; contractAddress: any }
+    | {
+        __typename: "LimitedFeeCollectModuleSettings";
+        type: CollectModules;
+        collectLimit: string;
+        recipient: any;
+        referralFee: number;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | {
+        __typename: "LimitedTimedFeeCollectModuleSettings";
+        type: CollectModules;
+        collectLimit: string;
+        recipient: any;
+        referralFee: number;
+        endTimestamp: any;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+    | {
+        __typename: "TimedFeeCollectModuleSettings";
+        type: CollectModules;
+        recipient: any;
+        referralFee: number;
+        endTimestamp: any;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | { __typename: "UnknownCollectModuleSettings" };
+  referenceModule?:
+    | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+    | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+    | { __typename?: "UnknownReferenceModuleSettings" }
+    | null;
+};
+
+export type CommentBaseFieldsFragment = {
+  __typename?: "Comment";
+  id: any;
+  createdAt: any;
+  appId?: any | null;
+  hidden: boolean;
+  reaction?: ReactionTypes | null;
+  mirrors: Array<any>;
+  hasCollectedByMe: boolean;
+  profile: {
+    __typename?: "Profile";
+    id: any;
+    name?: string | null;
+    bio?: string | null;
+    isFollowedByMe: boolean;
+    isFollowing: boolean;
+    followNftAddress?: any | null;
+    metadata?: any | null;
+    isDefault: boolean;
+    handle: any;
+    ownedBy: any;
+    attributes?: Array<{
+      __typename?: "Attribute";
+      displayType?: string | null;
+      traitType?: string | null;
+      key: string;
+      value: string;
+    }> | null;
+    picture?:
+      | {
+          __typename?: "MediaSet";
+          original: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          };
+          small?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+          medium?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+        }
+      | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+      | null;
+    coverPicture?:
+      | {
+          __typename?: "MediaSet";
+          original: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          };
+          small?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+          medium?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+        }
+      | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+      | null;
+    dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+    stats: {
+      __typename?: "ProfileStats";
+      totalFollowers: number;
+      totalFollowing: number;
+      totalPosts: number;
+      totalComments: number;
+      totalMirrors: number;
+      totalPublications: number;
+      totalCollects: number;
+    };
+    followModule?:
+      | {
+          __typename?: "FeeFollowModuleSettings";
+          type: FollowModules;
+          recipient: any;
+          amount: {
+            __typename?: "ModuleFeeAmount";
+            value: string;
+            asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+          };
+        }
+      | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+      | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+      | { __typename?: "UnknownFollowModuleSettings" }
+      | null;
+  };
+  stats: {
+    __typename?: "PublicationStats";
+    totalAmountOfMirrors: number;
+    totalAmountOfCollects: number;
+    totalAmountOfComments: number;
+  };
+  metadata: {
+    __typename?: "MetadataOutput";
+    name?: string | null;
+    description?: any | null;
+    content?: any | null;
+    media: Array<{
+      __typename?: "MediaSet";
+      original: {
+        __typename?: "Media";
+        url: any;
+        width?: number | null;
+        height?: number | null;
+        mimeType?: any | null;
+      };
+      small?: {
+        __typename?: "Media";
+        url: any;
+        width?: number | null;
+        height?: number | null;
+        mimeType?: any | null;
+      } | null;
+      medium?: {
+        __typename?: "Media";
+        url: any;
+        width?: number | null;
+        height?: number | null;
+        mimeType?: any | null;
+      } | null;
+    }>;
+    attributes: Array<{
+      __typename?: "MetadataAttributeOutput";
+      displayType?: PublicationMetadataDisplayTypes | null;
+      traitType?: string | null;
+      value?: string | null;
+    }>;
+  };
+  collectModule:
+    | {
+        __typename: "FeeCollectModuleSettings";
+        type: CollectModules;
+        recipient: any;
+        referralFee: number;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | { __typename: "FreeCollectModuleSettings"; type: CollectModules; followerOnly: boolean; contractAddress: any }
+    | {
+        __typename: "LimitedFeeCollectModuleSettings";
+        type: CollectModules;
+        collectLimit: string;
+        recipient: any;
+        referralFee: number;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | {
+        __typename: "LimitedTimedFeeCollectModuleSettings";
+        type: CollectModules;
+        collectLimit: string;
+        recipient: any;
+        referralFee: number;
+        endTimestamp: any;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+    | {
+        __typename: "TimedFeeCollectModuleSettings";
+        type: CollectModules;
+        recipient: any;
+        referralFee: number;
+        endTimestamp: any;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | { __typename: "UnknownCollectModuleSettings" };
+  referenceModule?:
+    | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+    | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+    | { __typename?: "UnknownReferenceModuleSettings" }
+    | null;
+};
+
+export type CommentFieldsFragment = {
+  __typename?: "Comment";
+  id: any;
+  createdAt: any;
+  appId?: any | null;
+  hidden: boolean;
+  reaction?: ReactionTypes | null;
+  mirrors: Array<any>;
+  hasCollectedByMe: boolean;
+  mainPost:
+    | {
+        __typename?: "Mirror";
+        id: any;
+        createdAt: any;
+        appId?: any | null;
+        hidden: boolean;
+        reaction?: ReactionTypes | null;
+        hasCollectedByMe: boolean;
+        mirrorOf:
+          | {
+              __typename?: "Comment";
+              id: any;
+              createdAt: any;
+              appId?: any | null;
+              hidden: boolean;
+              reaction?: ReactionTypes | null;
+              mirrors: Array<any>;
+              hasCollectedByMe: boolean;
+              mainPost:
+                | {
+                    __typename?: "Mirror";
+                    id: any;
+                    createdAt: any;
+                    appId?: any | null;
+                    hidden: boolean;
+                    reaction?: ReactionTypes | null;
+                    hasCollectedByMe: boolean;
+                    profile: {
+                      __typename?: "Profile";
+                      id: any;
+                      name?: string | null;
+                      bio?: string | null;
+                      isFollowedByMe: boolean;
+                      isFollowing: boolean;
+                      followNftAddress?: any | null;
+                      metadata?: any | null;
+                      isDefault: boolean;
+                      handle: any;
+                      ownedBy: any;
+                      attributes?: Array<{
+                        __typename?: "Attribute";
+                        displayType?: string | null;
+                        traitType?: string | null;
+                        key: string;
+                        value: string;
+                      }> | null;
+                      picture?:
+                        | {
+                            __typename?: "MediaSet";
+                            original: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            };
+                            small?: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            } | null;
+                            medium?: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            } | null;
+                          }
+                        | {
+                            __typename?: "NftImage";
+                            contractAddress: any;
+                            tokenId: string;
+                            uri: any;
+                            verified: boolean;
+                          }
+                        | null;
+                      coverPicture?:
+                        | {
+                            __typename?: "MediaSet";
+                            original: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            };
+                            small?: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            } | null;
+                            medium?: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            } | null;
+                          }
+                        | {
+                            __typename?: "NftImage";
+                            contractAddress: any;
+                            tokenId: string;
+                            uri: any;
+                            verified: boolean;
+                          }
+                        | null;
+                      dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+                      stats: {
+                        __typename?: "ProfileStats";
+                        totalFollowers: number;
+                        totalFollowing: number;
+                        totalPosts: number;
+                        totalComments: number;
+                        totalMirrors: number;
+                        totalPublications: number;
+                        totalCollects: number;
+                      };
+                      followModule?:
+                        | {
+                            __typename?: "FeeFollowModuleSettings";
+                            type: FollowModules;
+                            recipient: any;
+                            amount: {
+                              __typename?: "ModuleFeeAmount";
+                              value: string;
+                              asset: {
+                                __typename?: "Erc20";
+                                name: string;
+                                symbol: string;
+                                decimals: number;
+                                address: any;
+                              };
+                            };
+                          }
+                        | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+                        | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+                        | { __typename?: "UnknownFollowModuleSettings" }
+                        | null;
+                    };
+                    stats: {
+                      __typename?: "PublicationStats";
+                      totalAmountOfMirrors: number;
+                      totalAmountOfCollects: number;
+                      totalAmountOfComments: number;
+                    };
+                    metadata: {
+                      __typename?: "MetadataOutput";
+                      name?: string | null;
+                      description?: any | null;
+                      content?: any | null;
+                      media: Array<{
+                        __typename?: "MediaSet";
+                        original: {
+                          __typename?: "Media";
+                          url: any;
+                          width?: number | null;
+                          height?: number | null;
+                          mimeType?: any | null;
+                        };
+                        small?: {
+                          __typename?: "Media";
+                          url: any;
+                          width?: number | null;
+                          height?: number | null;
+                          mimeType?: any | null;
+                        } | null;
+                        medium?: {
+                          __typename?: "Media";
+                          url: any;
+                          width?: number | null;
+                          height?: number | null;
+                          mimeType?: any | null;
+                        } | null;
+                      }>;
+                      attributes: Array<{
+                        __typename?: "MetadataAttributeOutput";
+                        displayType?: PublicationMetadataDisplayTypes | null;
+                        traitType?: string | null;
+                        value?: string | null;
+                      }>;
+                    };
+                    collectModule:
+                      | {
+                          __typename: "FeeCollectModuleSettings";
+                          type: CollectModules;
+                          recipient: any;
+                          referralFee: number;
+                          amount: {
+                            __typename?: "ModuleFeeAmount";
+                            value: string;
+                            asset: {
+                              __typename?: "Erc20";
+                              name: string;
+                              symbol: string;
+                              decimals: number;
+                              address: any;
+                            };
+                          };
+                        }
+                      | {
+                          __typename: "FreeCollectModuleSettings";
+                          type: CollectModules;
+                          followerOnly: boolean;
+                          contractAddress: any;
+                        }
+                      | {
+                          __typename: "LimitedFeeCollectModuleSettings";
+                          type: CollectModules;
+                          collectLimit: string;
+                          recipient: any;
+                          referralFee: number;
+                          amount: {
+                            __typename?: "ModuleFeeAmount";
+                            value: string;
+                            asset: {
+                              __typename?: "Erc20";
+                              name: string;
+                              symbol: string;
+                              decimals: number;
+                              address: any;
+                            };
+                          };
+                        }
+                      | {
+                          __typename: "LimitedTimedFeeCollectModuleSettings";
+                          type: CollectModules;
+                          collectLimit: string;
+                          recipient: any;
+                          referralFee: number;
+                          endTimestamp: any;
+                          amount: {
+                            __typename?: "ModuleFeeAmount";
+                            value: string;
+                            asset: {
+                              __typename?: "Erc20";
+                              name: string;
+                              symbol: string;
+                              decimals: number;
+                              address: any;
+                            };
+                          };
+                        }
+                      | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+                      | {
+                          __typename: "TimedFeeCollectModuleSettings";
+                          type: CollectModules;
+                          recipient: any;
+                          referralFee: number;
+                          endTimestamp: any;
+                          amount: {
+                            __typename?: "ModuleFeeAmount";
+                            value: string;
+                            asset: {
+                              __typename?: "Erc20";
+                              name: string;
+                              symbol: string;
+                              decimals: number;
+                              address: any;
+                            };
+                          };
+                        }
+                      | { __typename: "UnknownCollectModuleSettings" };
+                    referenceModule?:
+                      | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+                      | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+                      | { __typename?: "UnknownReferenceModuleSettings" }
+                      | null;
+                  }
+                | {
+                    __typename?: "Post";
+                    id: any;
+                    createdAt: any;
+                    appId?: any | null;
+                    hidden: boolean;
+                    reaction?: ReactionTypes | null;
+                    mirrors: Array<any>;
+                    hasCollectedByMe: boolean;
+                    profile: {
+                      __typename?: "Profile";
+                      id: any;
+                      name?: string | null;
+                      bio?: string | null;
+                      isFollowedByMe: boolean;
+                      isFollowing: boolean;
+                      followNftAddress?: any | null;
+                      metadata?: any | null;
+                      isDefault: boolean;
+                      handle: any;
+                      ownedBy: any;
+                      attributes?: Array<{
+                        __typename?: "Attribute";
+                        displayType?: string | null;
+                        traitType?: string | null;
+                        key: string;
+                        value: string;
+                      }> | null;
+                      picture?:
+                        | {
+                            __typename?: "MediaSet";
+                            original: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            };
+                            small?: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            } | null;
+                            medium?: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            } | null;
+                          }
+                        | {
+                            __typename?: "NftImage";
+                            contractAddress: any;
+                            tokenId: string;
+                            uri: any;
+                            verified: boolean;
+                          }
+                        | null;
+                      coverPicture?:
+                        | {
+                            __typename?: "MediaSet";
+                            original: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            };
+                            small?: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            } | null;
+                            medium?: {
+                              __typename?: "Media";
+                              url: any;
+                              width?: number | null;
+                              height?: number | null;
+                              mimeType?: any | null;
+                            } | null;
+                          }
+                        | {
+                            __typename?: "NftImage";
+                            contractAddress: any;
+                            tokenId: string;
+                            uri: any;
+                            verified: boolean;
+                          }
+                        | null;
+                      dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+                      stats: {
+                        __typename?: "ProfileStats";
+                        totalFollowers: number;
+                        totalFollowing: number;
+                        totalPosts: number;
+                        totalComments: number;
+                        totalMirrors: number;
+                        totalPublications: number;
+                        totalCollects: number;
+                      };
+                      followModule?:
+                        | {
+                            __typename?: "FeeFollowModuleSettings";
+                            type: FollowModules;
+                            recipient: any;
+                            amount: {
+                              __typename?: "ModuleFeeAmount";
+                              value: string;
+                              asset: {
+                                __typename?: "Erc20";
+                                name: string;
+                                symbol: string;
+                                decimals: number;
+                                address: any;
+                              };
+                            };
+                          }
+                        | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+                        | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+                        | { __typename?: "UnknownFollowModuleSettings" }
+                        | null;
+                    };
+                    stats: {
+                      __typename?: "PublicationStats";
+                      totalAmountOfMirrors: number;
+                      totalAmountOfCollects: number;
+                      totalAmountOfComments: number;
+                    };
+                    metadata: {
+                      __typename?: "MetadataOutput";
+                      name?: string | null;
+                      description?: any | null;
+                      content?: any | null;
+                      media: Array<{
+                        __typename?: "MediaSet";
+                        original: {
+                          __typename?: "Media";
+                          url: any;
+                          width?: number | null;
+                          height?: number | null;
+                          mimeType?: any | null;
+                        };
+                        small?: {
+                          __typename?: "Media";
+                          url: any;
+                          width?: number | null;
+                          height?: number | null;
+                          mimeType?: any | null;
+                        } | null;
+                        medium?: {
+                          __typename?: "Media";
+                          url: any;
+                          width?: number | null;
+                          height?: number | null;
+                          mimeType?: any | null;
+                        } | null;
+                      }>;
+                      attributes: Array<{
+                        __typename?: "MetadataAttributeOutput";
+                        displayType?: PublicationMetadataDisplayTypes | null;
+                        traitType?: string | null;
+                        value?: string | null;
+                      }>;
+                    };
+                    collectModule:
+                      | {
+                          __typename: "FeeCollectModuleSettings";
+                          type: CollectModules;
+                          recipient: any;
+                          referralFee: number;
+                          amount: {
+                            __typename?: "ModuleFeeAmount";
+                            value: string;
+                            asset: {
+                              __typename?: "Erc20";
+                              name: string;
+                              symbol: string;
+                              decimals: number;
+                              address: any;
+                            };
+                          };
+                        }
+                      | {
+                          __typename: "FreeCollectModuleSettings";
+                          type: CollectModules;
+                          followerOnly: boolean;
+                          contractAddress: any;
+                        }
+                      | {
+                          __typename: "LimitedFeeCollectModuleSettings";
+                          type: CollectModules;
+                          collectLimit: string;
+                          recipient: any;
+                          referralFee: number;
+                          amount: {
+                            __typename?: "ModuleFeeAmount";
+                            value: string;
+                            asset: {
+                              __typename?: "Erc20";
+                              name: string;
+                              symbol: string;
+                              decimals: number;
+                              address: any;
+                            };
+                          };
+                        }
+                      | {
+                          __typename: "LimitedTimedFeeCollectModuleSettings";
+                          type: CollectModules;
+                          collectLimit: string;
+                          recipient: any;
+                          referralFee: number;
+                          endTimestamp: any;
+                          amount: {
+                            __typename?: "ModuleFeeAmount";
+                            value: string;
+                            asset: {
+                              __typename?: "Erc20";
+                              name: string;
+                              symbol: string;
+                              decimals: number;
+                              address: any;
+                            };
+                          };
+                        }
+                      | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+                      | {
+                          __typename: "TimedFeeCollectModuleSettings";
+                          type: CollectModules;
+                          recipient: any;
+                          referralFee: number;
+                          endTimestamp: any;
+                          amount: {
+                            __typename?: "ModuleFeeAmount";
+                            value: string;
+                            asset: {
+                              __typename?: "Erc20";
+                              name: string;
+                              symbol: string;
+                              decimals: number;
+                              address: any;
+                            };
+                          };
+                        }
+                      | { __typename: "UnknownCollectModuleSettings" };
+                    referenceModule?:
+                      | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+                      | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+                      | { __typename?: "UnknownReferenceModuleSettings" }
+                      | null;
+                  };
+              profile: {
+                __typename?: "Profile";
+                id: any;
+                name?: string | null;
+                bio?: string | null;
+                isFollowedByMe: boolean;
+                isFollowing: boolean;
+                followNftAddress?: any | null;
+                metadata?: any | null;
+                isDefault: boolean;
+                handle: any;
+                ownedBy: any;
+                attributes?: Array<{
+                  __typename?: "Attribute";
+                  displayType?: string | null;
+                  traitType?: string | null;
+                  key: string;
+                  value: string;
+                }> | null;
+                picture?:
+                  | {
+                      __typename?: "MediaSet";
+                      original: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      };
+                      small?: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      } | null;
+                      medium?: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      } | null;
+                    }
+                  | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+                  | null;
+                coverPicture?:
+                  | {
+                      __typename?: "MediaSet";
+                      original: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      };
+                      small?: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      } | null;
+                      medium?: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      } | null;
+                    }
+                  | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+                  | null;
+                dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+                stats: {
+                  __typename?: "ProfileStats";
+                  totalFollowers: number;
+                  totalFollowing: number;
+                  totalPosts: number;
+                  totalComments: number;
+                  totalMirrors: number;
+                  totalPublications: number;
+                  totalCollects: number;
+                };
+                followModule?:
+                  | {
+                      __typename?: "FeeFollowModuleSettings";
+                      type: FollowModules;
+                      recipient: any;
+                      amount: {
+                        __typename?: "ModuleFeeAmount";
+                        value: string;
+                        asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                      };
+                    }
+                  | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+                  | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+                  | { __typename?: "UnknownFollowModuleSettings" }
+                  | null;
+              };
+              stats: {
+                __typename?: "PublicationStats";
+                totalAmountOfMirrors: number;
+                totalAmountOfCollects: number;
+                totalAmountOfComments: number;
+              };
+              metadata: {
+                __typename?: "MetadataOutput";
+                name?: string | null;
+                description?: any | null;
+                content?: any | null;
+                media: Array<{
+                  __typename?: "MediaSet";
+                  original: {
+                    __typename?: "Media";
+                    url: any;
+                    width?: number | null;
+                    height?: number | null;
+                    mimeType?: any | null;
+                  };
+                  small?: {
+                    __typename?: "Media";
+                    url: any;
+                    width?: number | null;
+                    height?: number | null;
+                    mimeType?: any | null;
+                  } | null;
+                  medium?: {
+                    __typename?: "Media";
+                    url: any;
+                    width?: number | null;
+                    height?: number | null;
+                    mimeType?: any | null;
+                  } | null;
+                }>;
+                attributes: Array<{
+                  __typename?: "MetadataAttributeOutput";
+                  displayType?: PublicationMetadataDisplayTypes | null;
+                  traitType?: string | null;
+                  value?: string | null;
+                }>;
+              };
+              collectModule:
+                | {
+                    __typename: "FeeCollectModuleSettings";
+                    type: CollectModules;
+                    recipient: any;
+                    referralFee: number;
+                    amount: {
+                      __typename?: "ModuleFeeAmount";
+                      value: string;
+                      asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                    };
+                  }
+                | {
+                    __typename: "FreeCollectModuleSettings";
+                    type: CollectModules;
+                    followerOnly: boolean;
+                    contractAddress: any;
+                  }
+                | {
+                    __typename: "LimitedFeeCollectModuleSettings";
+                    type: CollectModules;
+                    collectLimit: string;
+                    recipient: any;
+                    referralFee: number;
+                    amount: {
+                      __typename?: "ModuleFeeAmount";
+                      value: string;
+                      asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                    };
+                  }
+                | {
+                    __typename: "LimitedTimedFeeCollectModuleSettings";
+                    type: CollectModules;
+                    collectLimit: string;
+                    recipient: any;
+                    referralFee: number;
+                    endTimestamp: any;
+                    amount: {
+                      __typename?: "ModuleFeeAmount";
+                      value: string;
+                      asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                    };
+                  }
+                | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+                | {
+                    __typename: "TimedFeeCollectModuleSettings";
+                    type: CollectModules;
+                    recipient: any;
+                    referralFee: number;
+                    endTimestamp: any;
+                    amount: {
+                      __typename?: "ModuleFeeAmount";
+                      value: string;
+                      asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                    };
+                  }
+                | { __typename: "UnknownCollectModuleSettings" };
+              referenceModule?:
+                | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+                | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+                | { __typename?: "UnknownReferenceModuleSettings" }
+                | null;
+            }
+          | {
+              __typename?: "Post";
+              id: any;
+              createdAt: any;
+              appId?: any | null;
+              hidden: boolean;
+              reaction?: ReactionTypes | null;
+              mirrors: Array<any>;
+              hasCollectedByMe: boolean;
+              profile: {
+                __typename?: "Profile";
+                id: any;
+                name?: string | null;
+                bio?: string | null;
+                isFollowedByMe: boolean;
+                isFollowing: boolean;
+                followNftAddress?: any | null;
+                metadata?: any | null;
+                isDefault: boolean;
+                handle: any;
+                ownedBy: any;
+                attributes?: Array<{
+                  __typename?: "Attribute";
+                  displayType?: string | null;
+                  traitType?: string | null;
+                  key: string;
+                  value: string;
+                }> | null;
+                picture?:
+                  | {
+                      __typename?: "MediaSet";
+                      original: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      };
+                      small?: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      } | null;
+                      medium?: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      } | null;
+                    }
+                  | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+                  | null;
+                coverPicture?:
+                  | {
+                      __typename?: "MediaSet";
+                      original: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      };
+                      small?: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      } | null;
+                      medium?: {
+                        __typename?: "Media";
+                        url: any;
+                        width?: number | null;
+                        height?: number | null;
+                        mimeType?: any | null;
+                      } | null;
+                    }
+                  | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+                  | null;
+                dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+                stats: {
+                  __typename?: "ProfileStats";
+                  totalFollowers: number;
+                  totalFollowing: number;
+                  totalPosts: number;
+                  totalComments: number;
+                  totalMirrors: number;
+                  totalPublications: number;
+                  totalCollects: number;
+                };
+                followModule?:
+                  | {
+                      __typename?: "FeeFollowModuleSettings";
+                      type: FollowModules;
+                      recipient: any;
+                      amount: {
+                        __typename?: "ModuleFeeAmount";
+                        value: string;
+                        asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                      };
+                    }
+                  | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+                  | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+                  | { __typename?: "UnknownFollowModuleSettings" }
+                  | null;
+              };
+              stats: {
+                __typename?: "PublicationStats";
+                totalAmountOfMirrors: number;
+                totalAmountOfCollects: number;
+                totalAmountOfComments: number;
+              };
+              metadata: {
+                __typename?: "MetadataOutput";
+                name?: string | null;
+                description?: any | null;
+                content?: any | null;
+                media: Array<{
+                  __typename?: "MediaSet";
+                  original: {
+                    __typename?: "Media";
+                    url: any;
+                    width?: number | null;
+                    height?: number | null;
+                    mimeType?: any | null;
+                  };
+                  small?: {
+                    __typename?: "Media";
+                    url: any;
+                    width?: number | null;
+                    height?: number | null;
+                    mimeType?: any | null;
+                  } | null;
+                  medium?: {
+                    __typename?: "Media";
+                    url: any;
+                    width?: number | null;
+                    height?: number | null;
+                    mimeType?: any | null;
+                  } | null;
+                }>;
+                attributes: Array<{
+                  __typename?: "MetadataAttributeOutput";
+                  displayType?: PublicationMetadataDisplayTypes | null;
+                  traitType?: string | null;
+                  value?: string | null;
+                }>;
+              };
+              collectModule:
+                | {
+                    __typename: "FeeCollectModuleSettings";
+                    type: CollectModules;
+                    recipient: any;
+                    referralFee: number;
+                    amount: {
+                      __typename?: "ModuleFeeAmount";
+                      value: string;
+                      asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                    };
+                  }
+                | {
+                    __typename: "FreeCollectModuleSettings";
+                    type: CollectModules;
+                    followerOnly: boolean;
+                    contractAddress: any;
+                  }
+                | {
+                    __typename: "LimitedFeeCollectModuleSettings";
+                    type: CollectModules;
+                    collectLimit: string;
+                    recipient: any;
+                    referralFee: number;
+                    amount: {
+                      __typename?: "ModuleFeeAmount";
+                      value: string;
+                      asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                    };
+                  }
+                | {
+                    __typename: "LimitedTimedFeeCollectModuleSettings";
+                    type: CollectModules;
+                    collectLimit: string;
+                    recipient: any;
+                    referralFee: number;
+                    endTimestamp: any;
+                    amount: {
+                      __typename?: "ModuleFeeAmount";
+                      value: string;
+                      asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                    };
+                  }
+                | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+                | {
+                    __typename: "TimedFeeCollectModuleSettings";
+                    type: CollectModules;
+                    recipient: any;
+                    referralFee: number;
+                    endTimestamp: any;
+                    amount: {
+                      __typename?: "ModuleFeeAmount";
+                      value: string;
+                      asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                    };
+                  }
+                | { __typename: "UnknownCollectModuleSettings" };
+              referenceModule?:
+                | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+                | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+                | { __typename?: "UnknownReferenceModuleSettings" }
+                | null;
+            };
+        profile: {
+          __typename?: "Profile";
+          id: any;
+          name?: string | null;
+          bio?: string | null;
+          isFollowedByMe: boolean;
+          isFollowing: boolean;
+          followNftAddress?: any | null;
+          metadata?: any | null;
+          isDefault: boolean;
+          handle: any;
+          ownedBy: any;
+          attributes?: Array<{
+            __typename?: "Attribute";
+            displayType?: string | null;
+            traitType?: string | null;
+            key: string;
+            value: string;
+          }> | null;
+          picture?:
+            | {
+                __typename?: "MediaSet";
+                original: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                };
+                small?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+                medium?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+              }
+            | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+            | null;
+          coverPicture?:
+            | {
+                __typename?: "MediaSet";
+                original: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                };
+                small?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+                medium?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+              }
+            | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+            | null;
+          dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+          stats: {
+            __typename?: "ProfileStats";
+            totalFollowers: number;
+            totalFollowing: number;
+            totalPosts: number;
+            totalComments: number;
+            totalMirrors: number;
+            totalPublications: number;
+            totalCollects: number;
+          };
+          followModule?:
+            | {
+                __typename?: "FeeFollowModuleSettings";
+                type: FollowModules;
+                recipient: any;
+                amount: {
+                  __typename?: "ModuleFeeAmount";
+                  value: string;
+                  asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                };
+              }
+            | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+            | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+            | { __typename?: "UnknownFollowModuleSettings" }
+            | null;
+        };
+        stats: {
+          __typename?: "PublicationStats";
+          totalAmountOfMirrors: number;
+          totalAmountOfCollects: number;
+          totalAmountOfComments: number;
+        };
+        metadata: {
+          __typename?: "MetadataOutput";
+          name?: string | null;
+          description?: any | null;
+          content?: any | null;
+          media: Array<{
+            __typename?: "MediaSet";
+            original: {
+              __typename?: "Media";
+              url: any;
+              width?: number | null;
+              height?: number | null;
+              mimeType?: any | null;
+            };
+            small?: {
+              __typename?: "Media";
+              url: any;
+              width?: number | null;
+              height?: number | null;
+              mimeType?: any | null;
+            } | null;
+            medium?: {
+              __typename?: "Media";
+              url: any;
+              width?: number | null;
+              height?: number | null;
+              mimeType?: any | null;
+            } | null;
+          }>;
+          attributes: Array<{
+            __typename?: "MetadataAttributeOutput";
+            displayType?: PublicationMetadataDisplayTypes | null;
+            traitType?: string | null;
+            value?: string | null;
+          }>;
+        };
+        collectModule:
+          | {
+              __typename: "FeeCollectModuleSettings";
+              type: CollectModules;
+              recipient: any;
+              referralFee: number;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | {
+              __typename: "FreeCollectModuleSettings";
+              type: CollectModules;
+              followerOnly: boolean;
+              contractAddress: any;
+            }
+          | {
+              __typename: "LimitedFeeCollectModuleSettings";
+              type: CollectModules;
+              collectLimit: string;
+              recipient: any;
+              referralFee: number;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | {
+              __typename: "LimitedTimedFeeCollectModuleSettings";
+              type: CollectModules;
+              collectLimit: string;
+              recipient: any;
+              referralFee: number;
+              endTimestamp: any;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+          | {
+              __typename: "TimedFeeCollectModuleSettings";
+              type: CollectModules;
+              recipient: any;
+              referralFee: number;
+              endTimestamp: any;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | { __typename: "UnknownCollectModuleSettings" };
+        referenceModule?:
+          | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+          | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+          | { __typename?: "UnknownReferenceModuleSettings" }
+          | null;
+      }
+    | {
+        __typename?: "Post";
+        id: any;
+        createdAt: any;
+        appId?: any | null;
+        hidden: boolean;
+        reaction?: ReactionTypes | null;
+        mirrors: Array<any>;
+        hasCollectedByMe: boolean;
+        profile: {
+          __typename?: "Profile";
+          id: any;
+          name?: string | null;
+          bio?: string | null;
+          isFollowedByMe: boolean;
+          isFollowing: boolean;
+          followNftAddress?: any | null;
+          metadata?: any | null;
+          isDefault: boolean;
+          handle: any;
+          ownedBy: any;
+          attributes?: Array<{
+            __typename?: "Attribute";
+            displayType?: string | null;
+            traitType?: string | null;
+            key: string;
+            value: string;
+          }> | null;
+          picture?:
+            | {
+                __typename?: "MediaSet";
+                original: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                };
+                small?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+                medium?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+              }
+            | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+            | null;
+          coverPicture?:
+            | {
+                __typename?: "MediaSet";
+                original: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                };
+                small?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+                medium?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+              }
+            | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+            | null;
+          dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+          stats: {
+            __typename?: "ProfileStats";
+            totalFollowers: number;
+            totalFollowing: number;
+            totalPosts: number;
+            totalComments: number;
+            totalMirrors: number;
+            totalPublications: number;
+            totalCollects: number;
+          };
+          followModule?:
+            | {
+                __typename?: "FeeFollowModuleSettings";
+                type: FollowModules;
+                recipient: any;
+                amount: {
+                  __typename?: "ModuleFeeAmount";
+                  value: string;
+                  asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                };
+              }
+            | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+            | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+            | { __typename?: "UnknownFollowModuleSettings" }
+            | null;
+        };
+        stats: {
+          __typename?: "PublicationStats";
+          totalAmountOfMirrors: number;
+          totalAmountOfCollects: number;
+          totalAmountOfComments: number;
+        };
+        metadata: {
+          __typename?: "MetadataOutput";
+          name?: string | null;
+          description?: any | null;
+          content?: any | null;
+          media: Array<{
+            __typename?: "MediaSet";
+            original: {
+              __typename?: "Media";
+              url: any;
+              width?: number | null;
+              height?: number | null;
+              mimeType?: any | null;
+            };
+            small?: {
+              __typename?: "Media";
+              url: any;
+              width?: number | null;
+              height?: number | null;
+              mimeType?: any | null;
+            } | null;
+            medium?: {
+              __typename?: "Media";
+              url: any;
+              width?: number | null;
+              height?: number | null;
+              mimeType?: any | null;
+            } | null;
+          }>;
+          attributes: Array<{
+            __typename?: "MetadataAttributeOutput";
+            displayType?: PublicationMetadataDisplayTypes | null;
+            traitType?: string | null;
+            value?: string | null;
+          }>;
+        };
+        collectModule:
+          | {
+              __typename: "FeeCollectModuleSettings";
+              type: CollectModules;
+              recipient: any;
+              referralFee: number;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | {
+              __typename: "FreeCollectModuleSettings";
+              type: CollectModules;
+              followerOnly: boolean;
+              contractAddress: any;
+            }
+          | {
+              __typename: "LimitedFeeCollectModuleSettings";
+              type: CollectModules;
+              collectLimit: string;
+              recipient: any;
+              referralFee: number;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | {
+              __typename: "LimitedTimedFeeCollectModuleSettings";
+              type: CollectModules;
+              collectLimit: string;
+              recipient: any;
+              referralFee: number;
+              endTimestamp: any;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+          | {
+              __typename: "TimedFeeCollectModuleSettings";
+              type: CollectModules;
+              recipient: any;
+              referralFee: number;
+              endTimestamp: any;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | { __typename: "UnknownCollectModuleSettings" };
+        referenceModule?:
+          | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+          | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+          | { __typename?: "UnknownReferenceModuleSettings" }
+          | null;
+      };
+  profile: {
+    __typename?: "Profile";
+    id: any;
+    name?: string | null;
+    bio?: string | null;
+    isFollowedByMe: boolean;
+    isFollowing: boolean;
+    followNftAddress?: any | null;
+    metadata?: any | null;
+    isDefault: boolean;
+    handle: any;
+    ownedBy: any;
+    attributes?: Array<{
+      __typename?: "Attribute";
+      displayType?: string | null;
+      traitType?: string | null;
+      key: string;
+      value: string;
+    }> | null;
+    picture?:
+      | {
+          __typename?: "MediaSet";
+          original: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          };
+          small?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+          medium?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+        }
+      | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+      | null;
+    coverPicture?:
+      | {
+          __typename?: "MediaSet";
+          original: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          };
+          small?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+          medium?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+        }
+      | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+      | null;
+    dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+    stats: {
+      __typename?: "ProfileStats";
+      totalFollowers: number;
+      totalFollowing: number;
+      totalPosts: number;
+      totalComments: number;
+      totalMirrors: number;
+      totalPublications: number;
+      totalCollects: number;
+    };
+    followModule?:
+      | {
+          __typename?: "FeeFollowModuleSettings";
+          type: FollowModules;
+          recipient: any;
+          amount: {
+            __typename?: "ModuleFeeAmount";
+            value: string;
+            asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+          };
+        }
+      | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+      | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+      | { __typename?: "UnknownFollowModuleSettings" }
+      | null;
+  };
+  stats: {
+    __typename?: "PublicationStats";
+    totalAmountOfMirrors: number;
+    totalAmountOfCollects: number;
+    totalAmountOfComments: number;
+  };
+  metadata: {
+    __typename?: "MetadataOutput";
+    name?: string | null;
+    description?: any | null;
+    content?: any | null;
+    media: Array<{
+      __typename?: "MediaSet";
+      original: {
+        __typename?: "Media";
+        url: any;
+        width?: number | null;
+        height?: number | null;
+        mimeType?: any | null;
+      };
+      small?: {
+        __typename?: "Media";
+        url: any;
+        width?: number | null;
+        height?: number | null;
+        mimeType?: any | null;
+      } | null;
+      medium?: {
+        __typename?: "Media";
+        url: any;
+        width?: number | null;
+        height?: number | null;
+        mimeType?: any | null;
+      } | null;
+    }>;
+    attributes: Array<{
+      __typename?: "MetadataAttributeOutput";
+      displayType?: PublicationMetadataDisplayTypes | null;
+      traitType?: string | null;
+      value?: string | null;
+    }>;
+  };
+  collectModule:
+    | {
+        __typename: "FeeCollectModuleSettings";
+        type: CollectModules;
+        recipient: any;
+        referralFee: number;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | { __typename: "FreeCollectModuleSettings"; type: CollectModules; followerOnly: boolean; contractAddress: any }
+    | {
+        __typename: "LimitedFeeCollectModuleSettings";
+        type: CollectModules;
+        collectLimit: string;
+        recipient: any;
+        referralFee: number;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | {
+        __typename: "LimitedTimedFeeCollectModuleSettings";
+        type: CollectModules;
+        collectLimit: string;
+        recipient: any;
+        referralFee: number;
+        endTimestamp: any;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+    | {
+        __typename: "TimedFeeCollectModuleSettings";
+        type: CollectModules;
+        recipient: any;
+        referralFee: number;
+        endTimestamp: any;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | { __typename: "UnknownCollectModuleSettings" };
+  referenceModule?:
+    | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+    | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+    | { __typename?: "UnknownReferenceModuleSettings" }
+    | null;
+};
+
+export type CommentMirrorOfFieldsFragment = {
+  __typename?: "Comment";
+  id: any;
+  createdAt: any;
+  appId?: any | null;
+  hidden: boolean;
+  reaction?: ReactionTypes | null;
+  mirrors: Array<any>;
+  hasCollectedByMe: boolean;
+  mainPost:
+    | {
+        __typename?: "Mirror";
+        id: any;
+        createdAt: any;
+        appId?: any | null;
+        hidden: boolean;
+        reaction?: ReactionTypes | null;
+        hasCollectedByMe: boolean;
+        profile: {
+          __typename?: "Profile";
+          id: any;
+          name?: string | null;
+          bio?: string | null;
+          isFollowedByMe: boolean;
+          isFollowing: boolean;
+          followNftAddress?: any | null;
+          metadata?: any | null;
+          isDefault: boolean;
+          handle: any;
+          ownedBy: any;
+          attributes?: Array<{
+            __typename?: "Attribute";
+            displayType?: string | null;
+            traitType?: string | null;
+            key: string;
+            value: string;
+          }> | null;
+          picture?:
+            | {
+                __typename?: "MediaSet";
+                original: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                };
+                small?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+                medium?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+              }
+            | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+            | null;
+          coverPicture?:
+            | {
+                __typename?: "MediaSet";
+                original: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                };
+                small?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+                medium?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+              }
+            | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+            | null;
+          dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+          stats: {
+            __typename?: "ProfileStats";
+            totalFollowers: number;
+            totalFollowing: number;
+            totalPosts: number;
+            totalComments: number;
+            totalMirrors: number;
+            totalPublications: number;
+            totalCollects: number;
+          };
+          followModule?:
+            | {
+                __typename?: "FeeFollowModuleSettings";
+                type: FollowModules;
+                recipient: any;
+                amount: {
+                  __typename?: "ModuleFeeAmount";
+                  value: string;
+                  asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                };
+              }
+            | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+            | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+            | { __typename?: "UnknownFollowModuleSettings" }
+            | null;
+        };
+        stats: {
+          __typename?: "PublicationStats";
+          totalAmountOfMirrors: number;
+          totalAmountOfCollects: number;
+          totalAmountOfComments: number;
+        };
+        metadata: {
+          __typename?: "MetadataOutput";
+          name?: string | null;
+          description?: any | null;
+          content?: any | null;
+          media: Array<{
+            __typename?: "MediaSet";
+            original: {
+              __typename?: "Media";
+              url: any;
+              width?: number | null;
+              height?: number | null;
+              mimeType?: any | null;
+            };
+            small?: {
+              __typename?: "Media";
+              url: any;
+              width?: number | null;
+              height?: number | null;
+              mimeType?: any | null;
+            } | null;
+            medium?: {
+              __typename?: "Media";
+              url: any;
+              width?: number | null;
+              height?: number | null;
+              mimeType?: any | null;
+            } | null;
+          }>;
+          attributes: Array<{
+            __typename?: "MetadataAttributeOutput";
+            displayType?: PublicationMetadataDisplayTypes | null;
+            traitType?: string | null;
+            value?: string | null;
+          }>;
+        };
+        collectModule:
+          | {
+              __typename: "FeeCollectModuleSettings";
+              type: CollectModules;
+              recipient: any;
+              referralFee: number;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | {
+              __typename: "FreeCollectModuleSettings";
+              type: CollectModules;
+              followerOnly: boolean;
+              contractAddress: any;
+            }
+          | {
+              __typename: "LimitedFeeCollectModuleSettings";
+              type: CollectModules;
+              collectLimit: string;
+              recipient: any;
+              referralFee: number;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | {
+              __typename: "LimitedTimedFeeCollectModuleSettings";
+              type: CollectModules;
+              collectLimit: string;
+              recipient: any;
+              referralFee: number;
+              endTimestamp: any;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+          | {
+              __typename: "TimedFeeCollectModuleSettings";
+              type: CollectModules;
+              recipient: any;
+              referralFee: number;
+              endTimestamp: any;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | { __typename: "UnknownCollectModuleSettings" };
+        referenceModule?:
+          | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+          | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+          | { __typename?: "UnknownReferenceModuleSettings" }
+          | null;
+      }
+    | {
+        __typename?: "Post";
+        id: any;
+        createdAt: any;
+        appId?: any | null;
+        hidden: boolean;
+        reaction?: ReactionTypes | null;
+        mirrors: Array<any>;
+        hasCollectedByMe: boolean;
+        profile: {
+          __typename?: "Profile";
+          id: any;
+          name?: string | null;
+          bio?: string | null;
+          isFollowedByMe: boolean;
+          isFollowing: boolean;
+          followNftAddress?: any | null;
+          metadata?: any | null;
+          isDefault: boolean;
+          handle: any;
+          ownedBy: any;
+          attributes?: Array<{
+            __typename?: "Attribute";
+            displayType?: string | null;
+            traitType?: string | null;
+            key: string;
+            value: string;
+          }> | null;
+          picture?:
+            | {
+                __typename?: "MediaSet";
+                original: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                };
+                small?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+                medium?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+              }
+            | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+            | null;
+          coverPicture?:
+            | {
+                __typename?: "MediaSet";
+                original: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                };
+                small?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+                medium?: {
+                  __typename?: "Media";
+                  url: any;
+                  width?: number | null;
+                  height?: number | null;
+                  mimeType?: any | null;
+                } | null;
+              }
+            | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+            | null;
+          dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+          stats: {
+            __typename?: "ProfileStats";
+            totalFollowers: number;
+            totalFollowing: number;
+            totalPosts: number;
+            totalComments: number;
+            totalMirrors: number;
+            totalPublications: number;
+            totalCollects: number;
+          };
+          followModule?:
+            | {
+                __typename?: "FeeFollowModuleSettings";
+                type: FollowModules;
+                recipient: any;
+                amount: {
+                  __typename?: "ModuleFeeAmount";
+                  value: string;
+                  asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+                };
+              }
+            | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+            | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+            | { __typename?: "UnknownFollowModuleSettings" }
+            | null;
+        };
+        stats: {
+          __typename?: "PublicationStats";
+          totalAmountOfMirrors: number;
+          totalAmountOfCollects: number;
+          totalAmountOfComments: number;
+        };
+        metadata: {
+          __typename?: "MetadataOutput";
+          name?: string | null;
+          description?: any | null;
+          content?: any | null;
+          media: Array<{
+            __typename?: "MediaSet";
+            original: {
+              __typename?: "Media";
+              url: any;
+              width?: number | null;
+              height?: number | null;
+              mimeType?: any | null;
+            };
+            small?: {
+              __typename?: "Media";
+              url: any;
+              width?: number | null;
+              height?: number | null;
+              mimeType?: any | null;
+            } | null;
+            medium?: {
+              __typename?: "Media";
+              url: any;
+              width?: number | null;
+              height?: number | null;
+              mimeType?: any | null;
+            } | null;
+          }>;
+          attributes: Array<{
+            __typename?: "MetadataAttributeOutput";
+            displayType?: PublicationMetadataDisplayTypes | null;
+            traitType?: string | null;
+            value?: string | null;
+          }>;
+        };
+        collectModule:
+          | {
+              __typename: "FeeCollectModuleSettings";
+              type: CollectModules;
+              recipient: any;
+              referralFee: number;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | {
+              __typename: "FreeCollectModuleSettings";
+              type: CollectModules;
+              followerOnly: boolean;
+              contractAddress: any;
+            }
+          | {
+              __typename: "LimitedFeeCollectModuleSettings";
+              type: CollectModules;
+              collectLimit: string;
+              recipient: any;
+              referralFee: number;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | {
+              __typename: "LimitedTimedFeeCollectModuleSettings";
+              type: CollectModules;
+              collectLimit: string;
+              recipient: any;
+              referralFee: number;
+              endTimestamp: any;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+          | {
+              __typename: "TimedFeeCollectModuleSettings";
+              type: CollectModules;
+              recipient: any;
+              referralFee: number;
+              endTimestamp: any;
+              amount: {
+                __typename?: "ModuleFeeAmount";
+                value: string;
+                asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+              };
+            }
+          | { __typename: "UnknownCollectModuleSettings" };
+        referenceModule?:
+          | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+          | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+          | { __typename?: "UnknownReferenceModuleSettings" }
+          | null;
+      };
+  profile: {
+    __typename?: "Profile";
+    id: any;
+    name?: string | null;
+    bio?: string | null;
+    isFollowedByMe: boolean;
+    isFollowing: boolean;
+    followNftAddress?: any | null;
+    metadata?: any | null;
+    isDefault: boolean;
+    handle: any;
+    ownedBy: any;
+    attributes?: Array<{
+      __typename?: "Attribute";
+      displayType?: string | null;
+      traitType?: string | null;
+      key: string;
+      value: string;
+    }> | null;
+    picture?:
+      | {
+          __typename?: "MediaSet";
+          original: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          };
+          small?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+          medium?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+        }
+      | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+      | null;
+    coverPicture?:
+      | {
+          __typename?: "MediaSet";
+          original: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          };
+          small?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+          medium?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+        }
+      | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+      | null;
+    dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+    stats: {
+      __typename?: "ProfileStats";
+      totalFollowers: number;
+      totalFollowing: number;
+      totalPosts: number;
+      totalComments: number;
+      totalMirrors: number;
+      totalPublications: number;
+      totalCollects: number;
+    };
+    followModule?:
+      | {
+          __typename?: "FeeFollowModuleSettings";
+          type: FollowModules;
+          recipient: any;
+          amount: {
+            __typename?: "ModuleFeeAmount";
+            value: string;
+            asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+          };
+        }
+      | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+      | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+      | { __typename?: "UnknownFollowModuleSettings" }
+      | null;
+  };
+  stats: {
+    __typename?: "PublicationStats";
+    totalAmountOfMirrors: number;
+    totalAmountOfCollects: number;
+    totalAmountOfComments: number;
+  };
+  metadata: {
+    __typename?: "MetadataOutput";
+    name?: string | null;
+    description?: any | null;
+    content?: any | null;
+    media: Array<{
+      __typename?: "MediaSet";
+      original: {
+        __typename?: "Media";
+        url: any;
+        width?: number | null;
+        height?: number | null;
+        mimeType?: any | null;
+      };
+      small?: {
+        __typename?: "Media";
+        url: any;
+        width?: number | null;
+        height?: number | null;
+        mimeType?: any | null;
+      } | null;
+      medium?: {
+        __typename?: "Media";
+        url: any;
+        width?: number | null;
+        height?: number | null;
+        mimeType?: any | null;
+      } | null;
+    }>;
+    attributes: Array<{
+      __typename?: "MetadataAttributeOutput";
+      displayType?: PublicationMetadataDisplayTypes | null;
+      traitType?: string | null;
+      value?: string | null;
+    }>;
+  };
+  collectModule:
+    | {
+        __typename: "FeeCollectModuleSettings";
+        type: CollectModules;
+        recipient: any;
+        referralFee: number;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | { __typename: "FreeCollectModuleSettings"; type: CollectModules; followerOnly: boolean; contractAddress: any }
+    | {
+        __typename: "LimitedFeeCollectModuleSettings";
+        type: CollectModules;
+        collectLimit: string;
+        recipient: any;
+        referralFee: number;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | {
+        __typename: "LimitedTimedFeeCollectModuleSettings";
+        type: CollectModules;
+        collectLimit: string;
+        recipient: any;
+        referralFee: number;
+        endTimestamp: any;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | { __typename: "RevertCollectModuleSettings"; type: CollectModules }
+    | {
+        __typename: "TimedFeeCollectModuleSettings";
+        type: CollectModules;
+        recipient: any;
+        referralFee: number;
+        endTimestamp: any;
+        amount: {
+          __typename?: "ModuleFeeAmount";
+          value: string;
+          asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+        };
+      }
+    | { __typename: "UnknownCollectModuleSettings" };
+  referenceModule?:
+    | { __typename?: "DegreesOfSeparationReferenceModuleSettings" }
+    | { __typename?: "FollowOnlyReferenceModuleSettings"; type: ReferenceModules }
+    | { __typename?: "UnknownReferenceModuleSettings" }
+    | null;
+};
+
+export type TxReceiptFieldsFragment = {
+  __typename?: "TransactionReceipt";
+  to?: any | null;
+  from: any;
+  contractAddress?: any | null;
+  transactionIndex: number;
+  root?: string | null;
+  gasUsed: string;
+  logsBloom: string;
+  blockHash: string;
+  transactionHash: any;
+  blockNumber: number;
+  confirmations: number;
+  cumulativeGasUsed: string;
+  effectiveGasPrice: string;
+  byzantium: boolean;
+  type: number;
+  status?: number | null;
+  logs: Array<{
+    __typename?: "Log";
+    blockNumber: number;
+    blockHash: string;
+    transactionIndex: number;
+    removed: boolean;
+    address: any;
+    data: string;
+    topics: Array<string>;
+    transactionHash: any;
+    logIndex: number;
+  }>;
+};
+
+export type WalletFieldsFragment = {
+  __typename?: "Wallet";
+  address: any;
+  defaultProfile?: {
+    __typename?: "Profile";
+    id: any;
+    name?: string | null;
+    bio?: string | null;
+    isFollowedByMe: boolean;
+    isFollowing: boolean;
+    followNftAddress?: any | null;
+    metadata?: any | null;
+    isDefault: boolean;
+    handle: any;
+    ownedBy: any;
+    attributes?: Array<{
+      __typename?: "Attribute";
+      displayType?: string | null;
+      traitType?: string | null;
+      key: string;
+      value: string;
+    }> | null;
+    picture?:
+      | {
+          __typename?: "MediaSet";
+          original: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          };
+          small?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+          medium?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+        }
+      | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+      | null;
+    coverPicture?:
+      | {
+          __typename?: "MediaSet";
+          original: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          };
+          small?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+          medium?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+        }
+      | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+      | null;
+    dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+    stats: {
+      __typename?: "ProfileStats";
+      totalFollowers: number;
+      totalFollowing: number;
+      totalPosts: number;
+      totalComments: number;
+      totalMirrors: number;
+      totalPublications: number;
+      totalCollects: number;
+    };
+    followModule?:
+      | {
+          __typename?: "FeeFollowModuleSettings";
+          type: FollowModules;
+          recipient: any;
+          amount: {
+            __typename?: "ModuleFeeAmount";
+            value: string;
+            asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+          };
+        }
+      | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+      | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+      | { __typename?: "UnknownFollowModuleSettings" }
+      | null;
+  } | null;
+};
+
+export type CommonPaginatedResultFieldsFragment = {
+  __typename?: "PaginatedResultInfo";
+  prev?: any | null;
+  next?: any | null;
+  totalCount?: number | null;
+};
+
+export type DefaultProfileQueryVariables = Exact<{
+  request: DefaultProfileRequest;
+}>;
+
+export type DefaultProfileQuery = {
+  __typename?: "Query";
+  defaultProfile?: {
+    __typename?: "Profile";
+    id: any;
+    name?: string | null;
+    bio?: string | null;
+    isFollowedByMe: boolean;
+    isFollowing: boolean;
+    followNftAddress?: any | null;
+    metadata?: any | null;
+    isDefault: boolean;
+    handle: any;
+    ownedBy: any;
+    attributes?: Array<{
+      __typename?: "Attribute";
+      displayType?: string | null;
+      traitType?: string | null;
+      key: string;
+      value: string;
+    }> | null;
+    picture?:
+      | {
+          __typename?: "MediaSet";
+          original: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          };
+          small?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+          medium?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+        }
+      | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+      | null;
+    coverPicture?:
+      | {
+          __typename?: "MediaSet";
+          original: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          };
+          small?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+          medium?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+        }
+      | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+      | null;
+    dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+    stats: {
+      __typename?: "ProfileStats";
+      totalFollowers: number;
+      totalFollowing: number;
+      totalPosts: number;
+      totalComments: number;
+      totalMirrors: number;
+      totalPublications: number;
+      totalCollects: number;
+    };
+    followModule?:
+      | {
+          __typename?: "FeeFollowModuleSettings";
+          type: FollowModules;
+          recipient: any;
+          amount: {
+            __typename?: "ModuleFeeAmount";
+            value: string;
+            asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+          };
+        }
+      | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+      | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+      | { __typename?: "UnknownFollowModuleSettings" }
+      | null;
+  } | null;
+};
+
+export type ProfileQueryVariables = Exact<{
+  request: SingleProfileQueryRequest;
+}>;
+
+export type ProfileQuery = {
+  __typename?: "Query";
+  profile?: {
+    __typename?: "Profile";
+    id: any;
+    name?: string | null;
+    bio?: string | null;
+    isFollowedByMe: boolean;
+    isFollowing: boolean;
+    followNftAddress?: any | null;
+    metadata?: any | null;
+    isDefault: boolean;
+    handle: any;
+    ownedBy: any;
+    attributes?: Array<{
+      __typename?: "Attribute";
+      displayType?: string | null;
+      traitType?: string | null;
+      key: string;
+      value: string;
+    }> | null;
+    picture?:
+      | {
+          __typename?: "MediaSet";
+          original: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          };
+          small?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+          medium?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+        }
+      | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+      | null;
+    coverPicture?:
+      | {
+          __typename?: "MediaSet";
+          original: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          };
+          small?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+          medium?: {
+            __typename?: "Media";
+            url: any;
+            width?: number | null;
+            height?: number | null;
+            mimeType?: any | null;
+          } | null;
+        }
+      | { __typename?: "NftImage"; contractAddress: any; tokenId: string; uri: any; verified: boolean }
+      | null;
+    dispatcher?: { __typename?: "Dispatcher"; address: any } | null;
+    stats: {
+      __typename?: "ProfileStats";
+      totalFollowers: number;
+      totalFollowing: number;
+      totalPosts: number;
+      totalComments: number;
+      totalMirrors: number;
+      totalPublications: number;
+      totalCollects: number;
+    };
+    followModule?:
+      | {
+          __typename?: "FeeFollowModuleSettings";
+          type: FollowModules;
+          recipient: any;
+          amount: {
+            __typename?: "ModuleFeeAmount";
+            value: string;
+            asset: { __typename?: "Erc20"; name: string; symbol: string; decimals: number; address: any };
+          };
+        }
+      | { __typename?: "ProfileFollowModuleSettings"; type: FollowModules }
+      | { __typename?: "RevertFollowModuleSettings"; type: FollowModules }
+      | { __typename?: "UnknownFollowModuleSettings" }
+      | null;
+  } | null;
+};
+
+export const MediaFieldsFragmentDoc = ({
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "MediaFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Media" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "url" } },
+          { kind: "Field", name: { kind: "Name", value: "width" } },
+          { kind: "Field", name: { kind: "Name", value: "height" } },
+          { kind: "Field", name: { kind: "Name", value: "mimeType" } },
+        ],
+      },
+    },
+  ],
+} as unknown) as DocumentNode<MediaFieldsFragment, unknown>;
+export const ProfileFieldsFragmentDoc = ({
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "ProfileFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Profile" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "bio" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "attributes" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "displayType" } },
+                { kind: "Field", name: { kind: "Name", value: "traitType" } },
+                { kind: "Field", name: { kind: "Name", value: "key" } },
+                { kind: "Field", name: { kind: "Name", value: "value" } },
+              ],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "isFollowedByMe" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "isFollowing" },
+            arguments: [{ kind: "Argument", name: { kind: "Name", value: "who" }, value: { kind: "NullValue" } }],
+          },
+          { kind: "Field", name: { kind: "Name", value: "followNftAddress" } },
+          { kind: "Field", name: { kind: "Name", value: "metadata" } },
+          { kind: "Field", name: { kind: "Name", value: "isDefault" } },
+          { kind: "Field", name: { kind: "Name", value: "handle" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "picture" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "InlineFragment",
+                  typeCondition: { kind: "NamedType", name: { kind: "Name", value: "NftImage" } },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "contractAddress" } },
+                      { kind: "Field", name: { kind: "Name", value: "tokenId" } },
+                      { kind: "Field", name: { kind: "Name", value: "uri" } },
+                      { kind: "Field", name: { kind: "Name", value: "verified" } },
+                    ],
+                  },
+                },
+                {
+                  kind: "InlineFragment",
+                  typeCondition: { kind: "NamedType", name: { kind: "Name", value: "MediaSet" } },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "original" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "MediaFields" } }],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "small" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "MediaFields" } }],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "medium" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "MediaFields" } }],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "coverPicture" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "InlineFragment",
+                  typeCondition: { kind: "NamedType", name: { kind: "Name", value: "NftImage" } },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "contractAddress" } },
+                      { kind: "Field", name: { kind: "Name", value: "tokenId" } },
+                      { kind: "Field", name: { kind: "Name", value: "uri" } },
+                      { kind: "Field", name: { kind: "Name", value: "verified" } },
+                    ],
+                  },
+                },
+                {
+                  kind: "InlineFragment",
+                  typeCondition: { kind: "NamedType", name: { kind: "Name", value: "MediaSet" } },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "original" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "MediaFields" } }],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "small" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "MediaFields" } }],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "medium" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "MediaFields" } }],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "ownedBy" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "dispatcher" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "address" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "stats" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "totalFollowers" } },
+                { kind: "Field", name: { kind: "Name", value: "totalFollowing" } },
+                { kind: "Field", name: { kind: "Name", value: "totalPosts" } },
+                { kind: "Field", name: { kind: "Name", value: "totalComments" } },
+                { kind: "Field", name: { kind: "Name", value: "totalMirrors" } },
+                { kind: "Field", name: { kind: "Name", value: "totalPublications" } },
+                { kind: "Field", name: { kind: "Name", value: "totalCollects" } },
+              ],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "followModule" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "InlineFragment",
+                  typeCondition: { kind: "NamedType", name: { kind: "Name", value: "FeeFollowModuleSettings" } },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "type" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "amount" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "asset" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "name" } },
+                                  { kind: "Field", name: { kind: "Name", value: "symbol" } },
+                                  { kind: "Field", name: { kind: "Name", value: "decimals" } },
+                                  { kind: "Field", name: { kind: "Name", value: "address" } },
+                                ],
+                              },
+                            },
+                            { kind: "Field", name: { kind: "Name", value: "value" } },
+                          ],
+                        },
+                      },
+                      { kind: "Field", name: { kind: "Name", value: "recipient" } },
+                    ],
+                  },
+                },
+                {
+                  kind: "InlineFragment",
+                  typeCondition: { kind: "NamedType", name: { kind: "Name", value: "ProfileFollowModuleSettings" } },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "type" } }],
+                  },
+                },
+                {
+                  kind: "InlineFragment",
+                  typeCondition: { kind: "NamedType", name: { kind: "Name", value: "RevertFollowModuleSettings" } },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "type" } }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown) as DocumentNode<ProfileFieldsFragment, unknown>;
+export const PublicationStatsFieldsFragmentDoc = ({
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "PublicationStatsFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "PublicationStats" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "totalAmountOfMirrors" } },
+          { kind: "Field", name: { kind: "Name", value: "totalAmountOfCollects" } },
+          { kind: "Field", name: { kind: "Name", value: "totalAmountOfComments" } },
+        ],
+      },
+    },
+  ],
+} as unknown) as DocumentNode<PublicationStatsFieldsFragment, unknown>;
+export const MetadataOutputFieldsFragmentDoc = ({
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "MetadataOutputFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "MetadataOutput" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "description" } },
+          { kind: "Field", name: { kind: "Name", value: "content" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "media" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "original" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "MediaFields" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "small" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "MediaFields" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "medium" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "MediaFields" } }],
+                  },
+                },
+              ],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "attributes" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "displayType" } },
+                { kind: "Field", name: { kind: "Name", value: "traitType" } },
+                { kind: "Field", name: { kind: "Name", value: "value" } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown) as DocumentNode<MetadataOutputFieldsFragment, unknown>;
+export const Erc20FieldsFragmentDoc = ({
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "Erc20Fields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Erc20" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "symbol" } },
+          { kind: "Field", name: { kind: "Name", value: "decimals" } },
+          { kind: "Field", name: { kind: "Name", value: "address" } },
+        ],
+      },
+    },
+  ],
+} as unknown) as DocumentNode<Erc20FieldsFragment, unknown>;
+export const CollectModuleFieldsFragmentDoc = ({
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CollectModuleFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "CollectModule" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "__typename" } },
+          {
+            kind: "InlineFragment",
+            typeCondition: { kind: "NamedType", name: { kind: "Name", value: "FreeCollectModuleSettings" } },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "type" } },
+                { kind: "Field", name: { kind: "Name", value: "followerOnly" } },
+                { kind: "Field", name: { kind: "Name", value: "contractAddress" } },
+              ],
+            },
+          },
+          {
+            kind: "InlineFragment",
+            typeCondition: { kind: "NamedType", name: { kind: "Name", value: "FeeCollectModuleSettings" } },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "type" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "amount" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "asset" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "Erc20Fields" } }],
+                        },
+                      },
+                      { kind: "Field", name: { kind: "Name", value: "value" } },
+                    ],
+                  },
+                },
+                { kind: "Field", name: { kind: "Name", value: "recipient" } },
+                { kind: "Field", name: { kind: "Name", value: "referralFee" } },
+              ],
+            },
+          },
+          {
+            kind: "InlineFragment",
+            typeCondition: { kind: "NamedType", name: { kind: "Name", value: "LimitedFeeCollectModuleSettings" } },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "type" } },
+                { kind: "Field", name: { kind: "Name", value: "collectLimit" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "amount" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "asset" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "Erc20Fields" } }],
+                        },
+                      },
+                      { kind: "Field", name: { kind: "Name", value: "value" } },
+                    ],
+                  },
+                },
+                { kind: "Field", name: { kind: "Name", value: "recipient" } },
+                { kind: "Field", name: { kind: "Name", value: "referralFee" } },
+              ],
+            },
+          },
+          {
+            kind: "InlineFragment",
+            typeCondition: { kind: "NamedType", name: { kind: "Name", value: "LimitedTimedFeeCollectModuleSettings" } },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "type" } },
+                { kind: "Field", name: { kind: "Name", value: "collectLimit" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "amount" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "asset" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "Erc20Fields" } }],
+                        },
+                      },
+                      { kind: "Field", name: { kind: "Name", value: "value" } },
+                    ],
+                  },
+                },
+                { kind: "Field", name: { kind: "Name", value: "recipient" } },
+                { kind: "Field", name: { kind: "Name", value: "referralFee" } },
+                { kind: "Field", name: { kind: "Name", value: "endTimestamp" } },
+              ],
+            },
+          },
+          {
+            kind: "InlineFragment",
+            typeCondition: { kind: "NamedType", name: { kind: "Name", value: "RevertCollectModuleSettings" } },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "type" } }],
+            },
+          },
+          {
+            kind: "InlineFragment",
+            typeCondition: { kind: "NamedType", name: { kind: "Name", value: "TimedFeeCollectModuleSettings" } },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "type" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "amount" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "asset" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "Erc20Fields" } }],
+                        },
+                      },
+                      { kind: "Field", name: { kind: "Name", value: "value" } },
+                    ],
+                  },
+                },
+                { kind: "Field", name: { kind: "Name", value: "recipient" } },
+                { kind: "Field", name: { kind: "Name", value: "referralFee" } },
+                { kind: "Field", name: { kind: "Name", value: "endTimestamp" } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown) as DocumentNode<CollectModuleFieldsFragment, unknown>;
+export const MirrorBaseFieldsFragmentDoc = ({
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "MirrorBaseFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Mirror" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "profile" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProfileFields" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "stats" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "PublicationStatsFields" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "metadata" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "MetadataOutputFields" } }],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "collectModule" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "CollectModuleFields" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "referenceModule" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "InlineFragment",
+                  typeCondition: {
+                    kind: "NamedType",
+                    name: { kind: "Name", value: "FollowOnlyReferenceModuleSettings" },
+                  },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "type" } }],
+                  },
+                },
+              ],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "appId" } },
+          { kind: "Field", name: { kind: "Name", value: "hidden" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "reaction" },
+            arguments: [{ kind: "Argument", name: { kind: "Name", value: "request" }, value: { kind: "NullValue" } }],
+          },
+          { kind: "Field", name: { kind: "Name", value: "hasCollectedByMe" } },
+        ],
+      },
+    },
+  ],
+} as unknown) as DocumentNode<MirrorBaseFieldsFragment, unknown>;
+export const PostFieldsFragmentDoc = ({
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "PostFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Post" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "profile" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProfileFields" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "stats" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "PublicationStatsFields" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "metadata" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "MetadataOutputFields" } }],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "collectModule" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "CollectModuleFields" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "referenceModule" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "InlineFragment",
+                  typeCondition: {
+                    kind: "NamedType",
+                    name: { kind: "Name", value: "FollowOnlyReferenceModuleSettings" },
+                  },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "type" } }],
+                  },
+                },
+              ],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "appId" } },
+          { kind: "Field", name: { kind: "Name", value: "hidden" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "reaction" },
+            arguments: [{ kind: "Argument", name: { kind: "Name", value: "request" }, value: { kind: "NullValue" } }],
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "mirrors" },
+            arguments: [{ kind: "Argument", name: { kind: "Name", value: "by" }, value: { kind: "NullValue" } }],
+          },
+          { kind: "Field", name: { kind: "Name", value: "hasCollectedByMe" } },
+        ],
+      },
+    },
+  ],
+} as unknown) as DocumentNode<PostFieldsFragment, unknown>;
+export const CommentBaseFieldsFragmentDoc = ({
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CommentBaseFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Comment" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "profile" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProfileFields" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "stats" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "PublicationStatsFields" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "metadata" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "MetadataOutputFields" } }],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "collectModule" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "CollectModuleFields" } }],
+            },
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "referenceModule" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "InlineFragment",
+                  typeCondition: {
+                    kind: "NamedType",
+                    name: { kind: "Name", value: "FollowOnlyReferenceModuleSettings" },
+                  },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "type" } }],
+                  },
+                },
+              ],
+            },
+          },
+          { kind: "Field", name: { kind: "Name", value: "appId" } },
+          { kind: "Field", name: { kind: "Name", value: "hidden" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "reaction" },
+            arguments: [{ kind: "Argument", name: { kind: "Name", value: "request" }, value: { kind: "NullValue" } }],
+          },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "mirrors" },
+            arguments: [{ kind: "Argument", name: { kind: "Name", value: "by" }, value: { kind: "NullValue" } }],
+          },
+          { kind: "Field", name: { kind: "Name", value: "hasCollectedByMe" } },
+        ],
+      },
+    },
+  ],
+} as unknown) as DocumentNode<CommentBaseFieldsFragment, unknown>;
+export const CommentMirrorOfFieldsFragmentDoc = ({
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CommentMirrorOfFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Comment" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "FragmentSpread", name: { kind: "Name", value: "CommentBaseFields" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "mainPost" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "InlineFragment",
+                  typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Post" } },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "PostFields" } }],
+                  },
+                },
+                {
+                  kind: "InlineFragment",
+                  typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Mirror" } },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "MirrorBaseFields" } }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown) as DocumentNode<CommentMirrorOfFieldsFragment, unknown>;
+export const CommentFieldsFragmentDoc = ({
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CommentFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Comment" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "FragmentSpread", name: { kind: "Name", value: "CommentBaseFields" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "mainPost" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "InlineFragment",
+                  typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Post" } },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "PostFields" } }],
+                  },
+                },
+                {
+                  kind: "InlineFragment",
+                  typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Mirror" } },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "FragmentSpread", name: { kind: "Name", value: "MirrorBaseFields" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "mirrorOf" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "InlineFragment",
+                              typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Post" } },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "PostFields" } }],
+                              },
+                            },
+                            {
+                              kind: "InlineFragment",
+                              typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Comment" } },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "FragmentSpread", name: { kind: "Name", value: "CommentMirrorOfFields" } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown) as DocumentNode<CommentFieldsFragment, unknown>;
+export const MirrorFieldsFragmentDoc = ({
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "MirrorFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Mirror" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "FragmentSpread", name: { kind: "Name", value: "MirrorBaseFields" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "mirrorOf" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "InlineFragment",
+                  typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Post" } },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "PostFields" } }],
+                  },
+                },
+                {
+                  kind: "InlineFragment",
+                  typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Comment" } },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "CommentFields" } }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown) as DocumentNode<MirrorFieldsFragment, unknown>;
+export const TxReceiptFieldsFragmentDoc = ({
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "TxReceiptFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "TransactionReceipt" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "to" } },
+          { kind: "Field", name: { kind: "Name", value: "from" } },
+          { kind: "Field", name: { kind: "Name", value: "contractAddress" } },
+          { kind: "Field", name: { kind: "Name", value: "transactionIndex" } },
+          { kind: "Field", name: { kind: "Name", value: "root" } },
+          { kind: "Field", name: { kind: "Name", value: "gasUsed" } },
+          { kind: "Field", name: { kind: "Name", value: "logsBloom" } },
+          { kind: "Field", name: { kind: "Name", value: "blockHash" } },
+          { kind: "Field", name: { kind: "Name", value: "transactionHash" } },
+          { kind: "Field", name: { kind: "Name", value: "blockNumber" } },
+          { kind: "Field", name: { kind: "Name", value: "confirmations" } },
+          { kind: "Field", name: { kind: "Name", value: "cumulativeGasUsed" } },
+          { kind: "Field", name: { kind: "Name", value: "effectiveGasPrice" } },
+          { kind: "Field", name: { kind: "Name", value: "byzantium" } },
+          { kind: "Field", name: { kind: "Name", value: "type" } },
+          { kind: "Field", name: { kind: "Name", value: "status" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "logs" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "blockNumber" } },
+                { kind: "Field", name: { kind: "Name", value: "blockHash" } },
+                { kind: "Field", name: { kind: "Name", value: "transactionIndex" } },
+                { kind: "Field", name: { kind: "Name", value: "removed" } },
+                { kind: "Field", name: { kind: "Name", value: "address" } },
+                { kind: "Field", name: { kind: "Name", value: "data" } },
+                { kind: "Field", name: { kind: "Name", value: "topics" } },
+                { kind: "Field", name: { kind: "Name", value: "transactionHash" } },
+                { kind: "Field", name: { kind: "Name", value: "logIndex" } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown) as DocumentNode<TxReceiptFieldsFragment, unknown>;
+export const WalletFieldsFragmentDoc = ({
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "WalletFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Wallet" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "address" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "defaultProfile" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProfileFields" } }],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown) as DocumentNode<WalletFieldsFragment, unknown>;
+export const CommonPaginatedResultFieldsFragmentDoc = ({
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CommonPaginatedResultFields" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "PaginatedResultInfo" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "prev" } },
+          { kind: "Field", name: { kind: "Name", value: "next" } },
+          { kind: "Field", name: { kind: "Name", value: "totalCount" } },
+        ],
+      },
+    },
+  ],
+} as unknown) as DocumentNode<CommonPaginatedResultFieldsFragment, unknown>;
+export const DefaultProfileDocument = ({
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "defaultProfile" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "request" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "DefaultProfileRequest" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "defaultProfile" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "request" },
+                value: { kind: "Variable", name: { kind: "Name", value: "request" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProfileFields" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ProfileFieldsFragmentDoc.definitions,
+    ...MediaFieldsFragmentDoc.definitions,
+  ],
+} as unknown) as DocumentNode<DefaultProfileQuery, DefaultProfileQueryVariables>;
+export const ProfileDocument = ({
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "profile" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "request" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "SingleProfileQueryRequest" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "profile" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "request" },
+                value: { kind: "Variable", name: { kind: "Name", value: "request" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "FragmentSpread", name: { kind: "Name", value: "ProfileFields" } }],
+            },
+          },
+        ],
+      },
+    },
+    ...ProfileFieldsFragmentDoc.definitions,
+    ...MediaFieldsFragmentDoc.definitions,
+  ],
+} as unknown) as DocumentNode<ProfileQuery, ProfileQueryVariables>;
+
+export interface PossibleTypesResultData {
+  possibleTypes: {
+    [key: string]: string[];
+  };
+}
+const result: PossibleTypesResultData = {
+  possibleTypes: {
+    CollectModule: [
+      "FeeCollectModuleSettings",
+      "FreeCollectModuleSettings",
+      "LimitedFeeCollectModuleSettings",
+      "LimitedTimedFeeCollectModuleSettings",
+      "RevertCollectModuleSettings",
+      "TimedFeeCollectModuleSettings",
+      "UnknownCollectModuleSettings",
+    ],
+    FeedItemRoot: ["Comment", "Post"],
+    FollowModule: [
+      "FeeFollowModuleSettings",
+      "ProfileFollowModuleSettings",
+      "RevertFollowModuleSettings",
+      "UnknownFollowModuleSettings",
+    ],
+    MainPostReference: ["Mirror", "Post"],
+    MentionPublication: ["Comment", "Post"],
+    MirrorablePublication: ["Comment", "Post"],
+    Notification: [
+      "NewCollectNotification",
+      "NewCommentNotification",
+      "NewFollowerNotification",
+      "NewMentionNotification",
+      "NewMirrorNotification",
+      "NewReactionNotification",
+    ],
+    ProfileMedia: ["MediaSet", "NftImage"],
+    ProxyActionStatusResultUnion: ["ProxyActionError", "ProxyActionQueued", "ProxyActionStatusResult"],
+    Publication: ["Comment", "Mirror", "Post"],
+    PublicationForSale: ["Comment", "Post"],
+    PublicationSearchResultItem: ["Comment", "Post"],
+    ReferenceModule: [
+      "DegreesOfSeparationReferenceModuleSettings",
+      "FollowOnlyReferenceModuleSettings",
+      "UnknownReferenceModuleSettings",
+    ],
+    RelayResult: ["RelayError", "RelayerResult"],
+    SearchResult: ["ProfileSearchResult", "PublicationSearchResult"],
+    TransactionResult: ["TransactionError", "TransactionIndexedResult"],
+  },
+};
+export default result;

--- a/packages/react-app-revamp/graphql/get-default-profile.graphql
+++ b/packages/react-app-revamp/graphql/get-default-profile.graphql
@@ -1,0 +1,6 @@
+
+query defaultProfile($request: DefaultProfileRequest!) {
+  defaultProfile(request: $request) {
+    ...ProfileFields
+  }
+}

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -1,8 +1,8 @@
 import { useRouter } from "next/router";
 import { useState } from "react";
 import toast from "react-hot-toast";
-import { chain, useProvider } from "wagmi";
-import { fetchBlockNumber, fetchEnsName, fetchToken, getAccount, readContract, readContracts } from "@wagmi/core";
+import { useProvider } from "wagmi";
+import { fetchBlockNumber, fetchToken, getAccount, readContract, readContracts } from "@wagmi/core";
 import { chains } from "@config/wagmi";
 import isUrlToImage from "@helpers/isUrlToImage";
 import { useStore } from "./store";
@@ -250,12 +250,7 @@ export function useContest() {
       }
 
       setContestName(results[0]);
-      const contestAuthorEns = await fetchEnsName({
-        //@ts-ignore
-        address: results[1],
-        chainId: chain.mainnet.id,
-      });
-      setContestAuthor(contestAuthorEns && contestAuthorEns !== null ? contestAuthorEns : results[1], results[1]);
+      setContestAuthor(results[1]);
       setContestMaxNumberSubmissionsPerUser(results[2]);
       setContestMaxProposalCount(results[3]);
       setVotingTokenAddress(results[4]);
@@ -263,7 +258,7 @@ export function useContest() {
       //@ts-ignore
       const votingTokenRawData = await fetchToken({ address: results[4], chainId });
       //@ts-ignore
-      const closingVoteDate = new Date(parseInt(results[6]) * 1000)
+      const closingVoteDate = new Date(parseInt(results[6]) * 1000);
       setVotingToken(votingTokenRawData);
       //@ts-ignore
       setSubmissionsOpen(new Date(parseInt(results[5]) * 1000));
@@ -271,21 +266,22 @@ export function useContest() {
       //@ts-ignore
       setVotesOpen(new Date(parseInt(results[7]) * 1000));
       // We want to track VoteCast event only 1H before the end of the contest
-      if(isBefore(new Date(), closingVoteDate)) {
-        if(differenceInHours(closingVoteDate, new Date()) <= 1) {
+      if (isBefore(new Date(), closingVoteDate)) {
+        if (differenceInHours(closingVoteDate, new Date()) <= 1) {
           // If the difference between the closing date (end of votes) and now is <= to 1h
           // reflect this in the state
-          setCanUpdateVotesInRealTime(true)
+          setCanUpdateVotesInRealTime(true);
         } else {
-          setCanUpdateVotesInRealTime(false)
+          setCanUpdateVotesInRealTime(false);
           // Otherwise, update the state 1h before the closing date (end of votes)
-          const delayBeforeVotesCanBeUpdated =  differenceInMilliseconds(closingVoteDate, new Date()) - hoursToMilliseconds(1)
+          const delayBeforeVotesCanBeUpdated =
+            differenceInMilliseconds(closingVoteDate, new Date()) - hoursToMilliseconds(1);
           setTimeout(() => {
-            setCanUpdateVotesInRealTime(true)
-          }, delayBeforeVotesCanBeUpdated)  
-        }  
+            setCanUpdateVotesInRealTime(true);
+          }, delayBeforeVotesCanBeUpdated);
+        }
       } else {
-        setCanUpdateVotesInRealTime(false)
+        setCanUpdateVotesInRealTime(false);
       }
 
       if (
@@ -315,7 +311,7 @@ export function useContest() {
         setSubmitProposalTokenAddress(results[4]);
         setSubmitProposalToken(votingTokenRawData);
       }
-      await checkIfCurrentUserQualifyToVote()
+      await checkIfCurrentUserQualifyToVote();
       if (accountData?.address) {
         // Current user votes
         await updateCurrentUserVotes();
@@ -472,19 +468,18 @@ export function useContest() {
         const timestampToCheck =
           //@ts-ignore
           delayedCurrentTimestamp >= timestampSnapshotRawData ? timestampSnapshotRawData : delayedCurrentTimestamp;
-          if(accountData?.address) {
-            const tokenUserWasHoldingAtSnapshotRawData = await readContract({
-              ...contractConfig,
-              functionName: "getVotes",
-              //@ts-ignore
-              args: [accountData?.address, timestampToCheck],
-            });
+        if (accountData?.address) {
+          const tokenUserWasHoldingAtSnapshotRawData = await readContract({
+            ...contractConfig,
+            functionName: "getVotes",
             //@ts-ignore
-            setDidUserPassSnapshotAndCanVote(tokenUserWasHoldingAtSnapshotRawData / 1e18 > 0);    
-          } else {
-            setDidUserPassSnapshotAndCanVote(false)
-          }
-
+            args: [accountData?.address, timestampToCheck],
+          });
+          //@ts-ignore
+          setDidUserPassSnapshotAndCanVote(tokenUserWasHoldingAtSnapshotRawData / 1e18 > 0);
+        } else {
+          setDidUserPassSnapshotAndCanVote(false);
+        }
       } else {
         setSnapshotTaken(false);
       }
@@ -525,7 +520,10 @@ export function useContest() {
         proposalsIdsRawData[0].map((data: any, index: number) => {
           proposalsIds.push({
             // for votes minus against votes if there are against votes
-            votes: proposalsIdsRawData[1][index].length == 1 ? proposalsIdsRawData[1][index][0] / 1e18 : proposalsIdsRawData[1][index][0] / 1e18 - proposalsIdsRawData[1][index][1] / 1e18,
+            votes:
+              proposalsIdsRawData[1][index].length == 1
+                ? proposalsIdsRawData[1][index][0] / 1e18
+                : proposalsIdsRawData[1][index][0] / 1e18 - proposalsIdsRawData[1][index][1] / 1e18,
             id: data,
           });
         });
@@ -588,15 +586,8 @@ export function useContest() {
     }, []);
 
     const data = proposalDataPerId[i][0];
-    // proposal author ENS
-    const author = await fetchEnsName({
-      address: data[0],
-      chainId: chain.mainnet.id,
-    });
-
     const proposalData = {
       authorEthereumAddress: data[0],
-      author: author ?? data[0],
       content: data[1],
       isContentImage: isUrlToImage(data[1]) ? true : false,
       exists: data[2],

--- a/packages/react-app-revamp/hooks/useContest/store.ts
+++ b/packages/react-app-revamp/hooks/useContest/store.ts
@@ -48,12 +48,14 @@ export const createStore = () => {
     setIsPageProposalsLoading: (value: boolean) => set({ isPageProposalsLoading: value }),
     setIsPageProposalsSuccess: (value: boolean) => set({ isPageProposalsSuccess: value }),
     setIsPageProposalsError: (value: boolean) => set({ isPageProposalsError: value }),
-    setCurrentPagePaginationProposals: (currentPage: number) => set({
-      currentPagePaginationProposals: currentPage
-    }),
-    setIndexPaginationProposalPerId: (proposalsPages: Array<any>) => set({
-      indexPaginationProposals: proposalsPages,
-    }),
+    setCurrentPagePaginationProposals: (currentPage: number) =>
+      set({
+        currentPagePaginationProposals: currentPage,
+      }),
+    setIndexPaginationProposalPerId: (proposalsPages: Array<any>) =>
+      set({
+        indexPaginationProposals: proposalsPages,
+      }),
     setTotalPagesPaginationProposals: (newTotal: number) => set({ totalPagesPaginationProposals: newTotal }),
     setHasPaginationProposalsNextPage: (hasNextPage: boolean) => set({ hasPaginationProposalsNextPage: hasNextPage }),
     setDownvotingAllowed: (isAllowed: boolean) => set({ downvotingAllowed: isAllowed }),

--- a/packages/react-app-revamp/layouts/LayoutViewContest/Sidebar/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/Sidebar/index.tsx
@@ -166,11 +166,7 @@ export const Sidebar = (props: any) => {
       <Button
         onClick={() => setIsTimelineModalOpen(true)}
         disabled={
-          isLoading ||
-          isError !== null ||
-          !isDate(submissionsOpen) ||
-          !isDate(votesOpen) ||
-          !isDate(votesClose)
+          isLoading || isError !== null || !isDate(submissionsOpen) || !isDate(votesOpen) || !isDate(votesClose)
         }
         intent="true-solid-outline"
         className={`
@@ -193,7 +189,6 @@ export const Sidebar = (props: any) => {
         </>
       )}
     </>
-    
   );
 };
 

--- a/packages/react-app-revamp/layouts/LayoutViewContest/Timeline/Countdown/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/Timeline/Countdown/index.tsx
@@ -14,7 +14,15 @@ import { CONTEST_STATUS } from "@helpers/contestStatus";
 // 3: Completed
 
 export const Countdown = () => {
-  const { listProposalsIds, contestMaxProposalCount, contestStatus, submissionsOpen, votesOpen, votesClose, setContestStatus } = useStore(
+  const {
+    listProposalsIds,
+    contestMaxProposalCount,
+    contestStatus,
+    submissionsOpen,
+    votesOpen,
+    votesClose,
+    setContestStatus,
+  } = useStore(
     state => ({
       //@ts-ignore
       submissionsOpen: state.submissionsOpen,
@@ -96,8 +104,14 @@ export const Countdown = () => {
   if (countdownUntilVotingOpen.isCountdownRunning || isBefore(new Date(), votesOpen)) {
     return (
       <>
-        <p className={`text-sm font-bold text-center text-true-white mb-1`}>{listProposalsIds.length >= contestMaxProposalCount ? "✋ Submissions closed ✋" : "✨ Submissions open ✨"}</p>
-        {<p className="text-2xs text-neutral-10 text-center mb-4">{listProposalsIds.length}/{contestMaxProposalCount.toString()} proposals submitted</p>}
+        <p className={`text-sm font-bold text-center text-true-white mb-1`}>
+          {listProposalsIds.length >= contestMaxProposalCount ? "✋ Submissions closed ✋" : "✨ Submissions open ✨"}
+        </p>
+        {
+          <p className="text-2xs text-neutral-10 text-center mb-4">
+            {listProposalsIds.length}/{contestMaxProposalCount.toString()} proposals submitted
+          </p>
+        }
         <p className={styles.label}>Voting opens in</p>
         <div className={styles.countdown}>
           {Object.keys(countdownUntilVotingOpen.countdown).map((unit: string) => (

--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -55,7 +55,7 @@ import useCheckSnapshotProgress from "./Timeline/Countdown/useCheckSnapshotProgr
 import DialogModalDeleteProposal from "@components/_pages/DialogModalDeleteProposal";
 import { switchNetwork } from "@wagmi/core";
 import { ErrorBoundary } from "react-error-boundary";
-import Countdown from "./Timeline/Countdown";
+import EtheuremAddress from "@components/EtheuremAddress";
 
 const LayoutViewContest = (props: any) => {
   const { children } = props;
@@ -189,7 +189,6 @@ const LayoutViewContest = (props: any) => {
           isLoading ? "pointer-events-none" : ""
         } flex-grow container mx-auto md:grid md:gap-6 md:grid-cols-12 md:-mb-20`}
       >
-
         <div
           className={`md:max-h-[calc(100vh-8rem)] ${styles.navbar} ${styles.withFakeSeparator} ${
             pathname === ROUTE_CONTEST_PROPOSAL ? "!hidden" : ""
@@ -205,18 +204,29 @@ const LayoutViewContest = (props: any) => {
             setIsTimelineModalOpen={setIsTimelineModalOpen}
           />
         </div>
-        {!isLoading && isSuccess && isDate(submissionsOpen) && isDate(votesOpen) && isDate(votesClose) && [CONTEST_STATUS.SUBMISSIONS_OPEN, CONTEST_STATUS.VOTING_OPEN].includes(contestStatus) && <div className="animate-appear text-center text-xs sticky bg-neutral-0 border-b border-neutral-4 border-solid top-10 z-10 font-bold -mx-5 px-5 md:hidden w-screen py-1">
-          <p className="text-center">
-            {!isLoading && isSuccess && isDate(submissionsOpen) && isDate(votesOpen) && isDate(votesClose) && <>
-              {contestStatus === CONTEST_STATUS.SUBMISSIONS_OPEN && <>
-                {listProposalsIds.length >= contestMaxProposalCount ? "✋ Submissions closed ✋" : "✨ Submissions open ✨"}
-              </>}
-              {contestStatus === CONTEST_STATUS.VOTING_OPEN && <>
-                ✨ Voting open ✨
-              </>}
-            </>}
-          </p>
-        </div>}
+        {!isLoading &&
+          isSuccess &&
+          isDate(submissionsOpen) &&
+          isDate(votesOpen) &&
+          isDate(votesClose) &&
+          [CONTEST_STATUS.SUBMISSIONS_OPEN, CONTEST_STATUS.VOTING_OPEN].includes(contestStatus) && (
+            <div className="animate-appear text-center text-xs sticky bg-neutral-0 border-b border-neutral-4 border-solid top-10 z-10 font-bold -mx-5 px-5 md:hidden w-screen py-1">
+              <p className="text-center">
+                {!isLoading && isSuccess && isDate(submissionsOpen) && isDate(votesOpen) && isDate(votesClose) && (
+                  <>
+                    {contestStatus === CONTEST_STATUS.SUBMISSIONS_OPEN && (
+                      <>
+                        {listProposalsIds.length >= contestMaxProposalCount
+                          ? "✋ Submissions closed ✋"
+                          : "✨ Submissions open ✨"}
+                      </>
+                    )}
+                    {contestStatus === CONTEST_STATUS.VOTING_OPEN && <>✨ Voting open ✨</>}
+                  </>
+                )}
+              </p>
+            </div>
+          )}
         <div
           className={`md:pt-5 md:pb-20 flex flex-col ${
             pathname === ROUTE_CONTEST_PROPOSAL ? "md:col-span-12" : "md:col-span-9"
@@ -301,7 +311,15 @@ const LayoutViewContest = (props: any) => {
                     }`}
                   >
                     <span className="uppercase tracking-wide pie-1ex">{contestName}</span>{" "}
-                    <span className="text-xs overflow-hidden text-neutral-8 text-ellipsis">by {contestAuthor}</span>
+                    <span className="text-xs overflow-hidden text-neutral-8 text-ellipsis">
+                      by &nbsp;
+                      <EtheuremAddress
+                        withHyphen={false}
+                        ethereumAddress={contestAuthor}
+                        shortenOnFallback={false}
+                        displayLensProfile={false}
+                      />
+                    </span>
                   </h2>
 
                   {contestPrompt && (

--- a/packages/react-app-revamp/package.json
+++ b/packages/react-app-revamp/package.json
@@ -7,11 +7,13 @@
     "start": "next start",
     "lint": "next lint",
     "prettier": "prettier --write \"./**/*.{js,jsx,ts,tsx,css,json}\"",
-    "export": "next export"
+    "export": "next export",
+    "lens:generate": "graphql-codegen"
   },
   "dependencies": {
     "@felte/react": "^1.2.2",
     "@felte/validator-zod": "^1.0.10",
+    "@graphql-codegen/fragment-matcher": "^3.3.1",
     "@headlessui/react": "^1.6.4",
     "@heroicons/react": "^1.0.6",
     "@rainbow-me/rainbowkit": "^0.4.1",
@@ -26,6 +28,7 @@
     "class-variance-authority": "^0.2.1",
     "date-fns": "^2.28.0",
     "ethers": "^5.6.8",
+    "graphql": "^16.6.0",
     "interweave": "^13.0.0",
     "interweave-autolink": "^5.0.0",
     "next": "12.1.6",
@@ -40,10 +43,15 @@
     "react-twitter-embed": "^4.0.4",
     "react-use": "^17.4.0",
     "tailwindcss": "^3.0.24",
+    "urql": "^3.0.3",
     "wagmi": "^0.5.8",
     "zod": "^3.17.3"
   },
   "devDependencies": {
+    "@graphql-codegen/cli": "^2.13.7",
+    "@graphql-codegen/typed-document-node": "^2.3.4",
+    "@graphql-codegen/typescript": "^2.7.4",
+    "@graphql-codegen/typescript-operations": "^2.5.4",
     "@tailwindcss/typography": "^0.5.2",
     "@types/node": "17.0.40",
     "@types/react": "18.0.11",

--- a/packages/react-app-revamp/pages/contest/[chain]/[address]/proposal/[proposal].tsx
+++ b/packages/react-app-revamp/pages/contest/[chain]/[address]/proposal/[proposal].tsx
@@ -63,7 +63,7 @@ const Page: NextPage = (props: PageProps) => {
     <h1 className='sr-only'>Proposal {proposal} - Contest {contestName ? contestName : address} </h1>
     {listProposalsData[proposal] && <div className='mt-6 animate-appear'>
         <ProposalContent 
-          author={listProposalsData[proposal]?.author}
+          author={listProposalsData[proposal]?.authorEthereumAddress}
           content={listProposalsData[proposal]?.content}
         />
         {contestStatus === CONTEST_STATUS.VOTING_OPEN && proposal && proposal !== null && !isProposalDeleted(listProposalsData[proposal]?.content) && <div className='flex flex-col items-center justify-center mt-10'>

--- a/packages/react-app-revamp/services/lens/getDefaultProfile.ts
+++ b/packages/react-app-revamp/services/lens/getDefaultProfile.ts
@@ -1,0 +1,19 @@
+import { client } from '@config/urql';
+import { DefaultProfileDocument } from '@graphql/generated';
+import type { DefaultProfileRequest } from '@graphql/generated';
+
+/**
+ * Get the default Lens profile associated to an Ethereum address
+ * @param request: `{ ethereumAddress }`
+ * @returns associated Lens profile or `undefined`
+ */
+export async function getDefaultProfile(request: DefaultProfileRequest) {
+  const profile = await client
+    .query(DefaultProfileDocument, {
+      request,
+    })
+    .toPromise()
+    return profile
+  }
+  
+

--- a/packages/react-app-revamp/tsconfig.json
+++ b/packages/react-app-revamp/tsconfig.json
@@ -22,7 +22,9 @@
       "@helpers/*": ["helpers/*"],
       "@hooks/*": ["hooks/*"],
       "@layouts/*": ["layouts/*"],
-      "@styles/*": ["styles/*"]
+      "@styles/*": ["styles/*"],
+      "@graphql/*": ["graphql/*"],
+      "@services/*": ["services/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@ampproject/remapping@^2.1.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
+  integrity sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.1.0"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
 "@ant-design/colors@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@ant-design/colors/-/colors-6.0.0.tgz#9b9366257cffcc47db42b9d0203bb592c13c0298"
@@ -78,6 +86,36 @@
   dependencies:
     "@apollo/client" latest
 
+"@ardatan/relay-compiler@12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@ardatan/relay-compiler/-/relay-compiler-12.0.0.tgz#2e4cca43088e807adc63450e8cab037020e91106"
+  integrity sha512-9anThAaj1dQr6IGmzBMcfzOQKTa5artjuPmw8NYK/fiGEMjADbSguBY2FMDykt+QhilR3wc9VA/3yVju7JHg7Q==
+  dependencies:
+    "@babel/core" "^7.14.0"
+    "@babel/generator" "^7.14.0"
+    "@babel/parser" "^7.14.0"
+    "@babel/runtime" "^7.0.0"
+    "@babel/traverse" "^7.14.0"
+    "@babel/types" "^7.0.0"
+    babel-preset-fbjs "^3.4.0"
+    chalk "^4.0.0"
+    fb-watchman "^2.0.0"
+    fbjs "^3.0.0"
+    glob "^7.1.1"
+    immutable "~3.7.6"
+    invariant "^2.2.4"
+    nullthrows "^1.1.1"
+    relay-runtime "12.0.0"
+    signedsource "^1.0.0"
+    yargs "^15.3.1"
+
+"@ardatan/sync-fetch@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@ardatan/sync-fetch/-/sync-fetch-0.0.1.tgz#3385d3feedceb60a896518a1db857ec1e945348f"
+  integrity sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA==
+  dependencies:
+    node-fetch "^2.6.1"
+
 "@babel/code-frame@7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
@@ -99,10 +137,22 @@
   dependencies:
     "@babel/highlight" "^7.14.5"
 
+"@babel/code-frame@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
+  integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
+  dependencies:
+    "@babel/highlight" "^7.18.6"
+
 "@babel/compat-data@^7.12.1", "@babel/compat-data@^7.13.11", "@babel/compat-data@^7.14.5", "@babel/compat-data@^7.14.7":
   version "7.14.7"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.14.7.tgz#7b047d7a3a89a67d2258dc61f604f098f1bc7e08"
   integrity sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==
+
+"@babel/compat-data@^7.19.3", "@babel/compat-data@^7.19.4":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.19.4.tgz#95c86de137bf0317f3a570e1b6e996b427299747"
+  integrity sha512-CHIGpJcUQ5lU9KrPHTjBMhVwQG6CQjxfg36fGXl3qk/Gik1WwWachaXFuo0uCWJT/mStOKtcbFJCaVLihC1CMw==
 
 "@babel/core@7.12.3":
   version "7.12.3"
@@ -147,6 +197,27 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
+"@babel/core@^7.14.0":
+  version "7.19.3"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.19.3.tgz#2519f62a51458f43b682d61583c3810e7dcee64c"
+  integrity sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==
+  dependencies:
+    "@ampproject/remapping" "^2.1.0"
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.19.3"
+    "@babel/helper-compilation-targets" "^7.19.3"
+    "@babel/helper-module-transforms" "^7.19.0"
+    "@babel/helpers" "^7.19.0"
+    "@babel/parser" "^7.19.3"
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.19.3"
+    "@babel/types" "^7.19.3"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.1"
+    semver "^6.3.0"
+
 "@babel/generator@^7.12.1", "@babel/generator@^7.14.8":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.14.8.tgz#bf86fd6af96cf3b74395a8ca409515f89423e070"
@@ -156,12 +227,28 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
+"@babel/generator@^7.14.0", "@babel/generator@^7.18.13", "@babel/generator@^7.19.3", "@babel/generator@^7.19.4":
+  version "7.19.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.19.5.tgz#da3f4b301c8086717eee9cab14da91b1fa5dcca7"
+  integrity sha512-DxbNz9Lz4aMZ99qPpO1raTbcrI1ZeYh+9NR9qhfkQIbFtVEqotHojEBxHzmxhVONkGt6VyrqVQcgpefMy9pqcg==
+  dependencies:
+    "@babel/types" "^7.19.4"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    jsesc "^2.5.1"
+
 "@babel/helper-annotate-as-pure@^7.0.0", "@babel/helper-annotate-as-pure@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.14.5.tgz#7bf478ec3b71726d56a8ca5775b046fc29879e61"
   integrity sha512-EivH9EgBIb+G8ij1B2jAwSH36WnGvkQSEC6CkX/6v6ZFlw5fVOHvsgGF4uiEHO2GzMvunZb6tDLQEQSdrdocrA==
   dependencies:
     "@babel/types" "^7.14.5"
+
+"@babel/helper-annotate-as-pure@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz#eaa49f6f80d5a33f9a5dd2276e6d6e451be0a6bb"
+  integrity sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==
+  dependencies:
+    "@babel/types" "^7.18.6"
 
 "@babel/helper-builder-binary-assignment-operator-visitor@^7.14.5":
   version "7.14.5"
@@ -181,6 +268,16 @@
     browserslist "^4.16.6"
     semver "^6.3.0"
 
+"@babel/helper-compilation-targets@^7.18.9", "@babel/helper-compilation-targets@^7.19.0", "@babel/helper-compilation-targets@^7.19.3":
+  version "7.19.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.3.tgz#a10a04588125675d7c7ae299af86fa1b2ee038ca"
+  integrity sha512-65ESqLGyGmLvgR0mst5AdW1FkNlj9rQsCKduzEoEPhBCDFGXvz2jW6bXFG6i0/MrV2s7hhXjjb2yAzcPuQlLwg==
+  dependencies:
+    "@babel/compat-data" "^7.19.3"
+    "@babel/helper-validator-option" "^7.18.6"
+    browserslist "^4.21.3"
+    semver "^6.3.0"
+
 "@babel/helper-create-class-features-plugin@^7.12.1", "@babel/helper-create-class-features-plugin@^7.14.5", "@babel/helper-create-class-features-plugin@^7.14.6":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.8.tgz#a6f8c3de208b1e5629424a9a63567f56501955fc"
@@ -192,6 +289,19 @@
     "@babel/helper-optimise-call-expression" "^7.14.5"
     "@babel/helper-replace-supers" "^7.14.5"
     "@babel/helper-split-export-declaration" "^7.14.5"
+
+"@babel/helper-create-class-features-plugin@^7.18.6":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.19.0.tgz#bfd6904620df4e46470bae4850d66be1054c404b"
+  integrity sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.19.0"
+    "@babel/helper-member-expression-to-functions" "^7.18.9"
+    "@babel/helper-optimise-call-expression" "^7.18.6"
+    "@babel/helper-replace-supers" "^7.18.9"
+    "@babel/helper-split-export-declaration" "^7.18.6"
 
 "@babel/helper-create-regexp-features-plugin@^7.14.5":
   version "7.14.5"
@@ -215,6 +325,11 @@
     resolve "^1.14.2"
     semver "^6.1.2"
 
+"@babel/helper-environment-visitor@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
+  integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
+
 "@babel/helper-explode-assignable-expression@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.14.5.tgz#8aa72e708205c7bb643e45c73b4386cdf2a1f645"
@@ -231,6 +346,14 @@
     "@babel/template" "^7.14.5"
     "@babel/types" "^7.14.5"
 
+"@babel/helper-function-name@^7.18.9", "@babel/helper-function-name@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz#941574ed5390682e872e52d3f38ce9d1bef4648c"
+  integrity sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==
+  dependencies:
+    "@babel/template" "^7.18.10"
+    "@babel/types" "^7.19.0"
+
 "@babel/helper-get-function-arity@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz#25fbfa579b0937eee1f3b805ece4ce398c431815"
@@ -245,6 +368,13 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-hoist-variables@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz#d4d2c8fb4baeaa5c68b99cc8245c56554f926678"
+  integrity sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==
+  dependencies:
+    "@babel/types" "^7.18.6"
+
 "@babel/helper-member-expression-to-functions@^7.14.5", "@babel/helper-member-expression-to-functions@^7.14.7":
   version "7.14.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz#97e56244beb94211fe277bd818e3a329c66f7970"
@@ -252,12 +382,26 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-member-expression-to-functions@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.18.9.tgz#1531661e8375af843ad37ac692c132841e2fd815"
+  integrity sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==
+  dependencies:
+    "@babel/types" "^7.18.9"
+
 "@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz#6d1a44df6a38c957aa7c312da076429f11b422f3"
   integrity sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==
   dependencies:
     "@babel/types" "^7.14.5"
+
+"@babel/helper-module-imports@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
+  integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
+  dependencies:
+    "@babel/types" "^7.18.6"
 
 "@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.14.5", "@babel/helper-module-transforms@^7.14.8":
   version "7.14.8"
@@ -273,6 +417,20 @@
     "@babel/traverse" "^7.14.8"
     "@babel/types" "^7.14.8"
 
+"@babel/helper-module-transforms@^7.18.6", "@babel/helper-module-transforms@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz#309b230f04e22c58c6a2c0c0c7e50b216d350c30"
+  integrity sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-module-imports" "^7.18.6"
+    "@babel/helper-simple-access" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/helper-validator-identifier" "^7.18.6"
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.19.0"
+    "@babel/types" "^7.19.0"
+
 "@babel/helper-optimise-call-expression@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz#f27395a8619e0665b3f0364cddb41c25d71b499c"
@@ -280,10 +438,22 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-optimise-call-expression@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz#9369aa943ee7da47edab2cb4e838acf09d290ffe"
+  integrity sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==
+  dependencies:
+    "@babel/types" "^7.18.6"
+
 "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.13.0", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz#5ac822ce97eec46741ab70a517971e443a70c5a9"
   integrity sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==
+
+"@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.18.9", "@babel/helper-plugin-utils@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz#4796bb14961521f0f8715990bee2fb6e51ce21bf"
+  integrity sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==
 
 "@babel/helper-remap-async-to-generator@^7.14.5":
   version "7.14.5"
@@ -304,12 +474,30 @@
     "@babel/traverse" "^7.14.5"
     "@babel/types" "^7.14.5"
 
+"@babel/helper-replace-supers@^7.18.6", "@babel/helper-replace-supers@^7.18.9":
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.19.1.tgz#e1592a9b4b368aa6bdb8784a711e0bcbf0612b78"
+  integrity sha512-T7ahH7wV0Hfs46SFh5Jz3s0B6+o8g3c+7TMxu7xKfmHikg7EAZ3I2Qk9LFhjxXq8sL7UkP5JflezNwoZa8WvWw==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-member-expression-to-functions" "^7.18.9"
+    "@babel/helper-optimise-call-expression" "^7.18.6"
+    "@babel/traverse" "^7.19.1"
+    "@babel/types" "^7.19.0"
+
 "@babel/helper-simple-access@^7.14.5", "@babel/helper-simple-access@^7.14.8":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz#82e1fec0644a7e775c74d305f212c39f8fe73924"
   integrity sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==
   dependencies:
     "@babel/types" "^7.14.8"
+
+"@babel/helper-simple-access@^7.18.6":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.19.4.tgz#be553f4951ac6352df2567f7daa19a0ee15668e7"
+  integrity sha512-f9Xq6WqBFqaDfbCzn2w85hwklswz5qsKlh7f08w4Y9yhJHpnNC0QemtSkK5YyOY8kPGvyiwdzZksGUhnGdaUIg==
+  dependencies:
+    "@babel/types" "^7.19.4"
 
 "@babel/helper-skip-transparent-expression-wrappers@^7.12.1", "@babel/helper-skip-transparent-expression-wrappers@^7.14.5":
   version "7.14.5"
@@ -318,6 +506,13 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-skip-transparent-expression-wrappers@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.18.9.tgz#778d87b3a758d90b471e7b9918f34a9a02eb5818"
+  integrity sha512-imytd2gHi3cJPsybLRbmFrF7u5BIEuI2cNheyKi3/iOBC63kNn3q8Crn2xVuESli0aM4KYsyEqKyS7lFL8YVtw==
+  dependencies:
+    "@babel/types" "^7.18.9"
+
 "@babel/helper-split-export-declaration@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz#22b23a54ef51c2b7605d851930c1976dd0bc693a"
@@ -325,15 +520,37 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-split-export-declaration@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz#7367949bc75b20c6d5a5d4a97bba2824ae8ef075"
+  integrity sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==
+  dependencies:
+    "@babel/types" "^7.18.6"
+
+"@babel/helper-string-parser@^7.19.4":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
+  integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
+
 "@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.14.8":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz#32be33a756f29e278a0d644fa08a2c9e0f88a34c"
   integrity sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==
 
+"@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.19.1":
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
+  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
+
 "@babel/helper-validator-option@^7.12.1", "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
   integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
+
+"@babel/helper-validator-option@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz#bf0d2b5a509b1f336099e4ff36e1a63aa5db4db8"
+  integrity sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==
 
 "@babel/helper-wrap-function@^7.14.5":
   version "7.14.5"
@@ -354,6 +571,15 @@
     "@babel/traverse" "^7.14.8"
     "@babel/types" "^7.14.8"
 
+"@babel/helpers@^7.19.0":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.19.4.tgz#42154945f87b8148df7203a25c31ba9a73be46c5"
+  integrity sha512-G+z3aOx2nfDHwX/kyVii5fJq+bgscg89/dJNWpYeKeBv3v9xX8EIabmx1k6u9LS04H7nROFVRVK+e3k0VHp+sw==
+  dependencies:
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.19.4"
+    "@babel/types" "^7.19.4"
+
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.5.tgz#6861a52f03966405001f6aa534a01a24d99e8cd9"
@@ -363,10 +589,24 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
+  integrity sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.18.6"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.12.3", "@babel/parser@^7.14.5", "@babel/parser@^7.14.8", "@babel/parser@^7.7.0":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.8.tgz#66fd41666b2d7b840bd5ace7f7416d5ac60208d4"
   integrity sha512-syoCQFOoo/fzkWDeM0dLEZi5xqurb5vuyzwIMNZRNun+N/9A4cUZeQaE7dTrB8jGaKuJRBtEOajtnmw0I5hvvA==
+
+"@babel/parser@^7.14.0", "@babel/parser@^7.16.8", "@babel/parser@^7.18.10", "@babel/parser@^7.19.3", "@babel/parser@^7.19.4":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.19.4.tgz#03c4339d2b8971eb3beca5252bafd9b9f79db3dc"
+  integrity sha512-qpVT7gtuOLjWeDTKLkJ6sryqLliBaFpAtGeqw5cs5giLldvh+Ch0plqnUMKoVAUS6ZEueQQiZV+p5pxtPitEsA==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.14.5":
   version "7.14.5"
@@ -393,6 +633,14 @@
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-proposal-class-properties@^7.0.0":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz#b110f59741895f7ec21a6fff696ec46265c446a3"
+  integrity sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.18.6"
+    "@babel/helper-plugin-utils" "^7.18.6"
 
 "@babel/plugin-proposal-class-properties@^7.12.1", "@babel/plugin-proposal-class-properties@^7.14.5":
   version "7.14.5"
@@ -484,6 +732,17 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
 
+"@babel/plugin-proposal-object-rest-spread@^7.0.0":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.19.4.tgz#a8fc86e8180ff57290c91a75d83fe658189b642d"
+  integrity sha512-wHmj6LDxVDnL+3WhXteUBaoM1aVILZODAUjg11kHqG4cOlfgMQGxw6aCgvrXrmaJR3Bn14oZhImyCPZzRpC93Q==
+  dependencies:
+    "@babel/compat-data" "^7.19.4"
+    "@babel/helper-compilation-targets" "^7.19.3"
+    "@babel/helper-plugin-utils" "^7.19.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
+    "@babel/plugin-transform-parameters" "^7.18.8"
+
 "@babel/plugin-proposal-object-rest-spread@^7.12.1", "@babel/plugin-proposal-object-rest-spread@^7.14.7":
   version "7.14.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.14.7.tgz#5920a2b3df7f7901df0205974c0641b13fd9d363"
@@ -561,7 +820,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-class-properties@^7.12.1", "@babel/plugin-syntax-class-properties@^7.12.13", "@babel/plugin-syntax-class-properties@^7.8.3":
+"@babel/plugin-syntax-class-properties@^7.0.0", "@babel/plugin-syntax-class-properties@^7.12.1", "@babel/plugin-syntax-class-properties@^7.12.13", "@babel/plugin-syntax-class-properties@^7.8.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz#b5c987274c4a3a82b89714796931a6b53544ae10"
   integrity sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==
@@ -596,6 +855,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
+"@babel/plugin-syntax-flow@^7.0.0", "@babel/plugin-syntax-flow@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.18.6.tgz#774d825256f2379d06139be0c723c4dd444f3ca1"
+  integrity sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
+
 "@babel/plugin-syntax-flow@^7.12.1":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.14.5.tgz#2ff654999497d7d7d142493260005263731da180"
@@ -616,6 +882,13 @@
   integrity sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-jsx@^7.0.0", "@babel/plugin-syntax-jsx@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz#a8feef63b010150abd97f1649ec296e849943ca0"
+  integrity sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
 
 "@babel/plugin-syntax-jsx@^7.14.5":
   version "7.14.5"
@@ -645,7 +918,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-syntax-object-rest-spread@^7.8.0", "@babel/plugin-syntax-object-rest-spread@^7.8.3":
+"@babel/plugin-syntax-object-rest-spread@^7.0.0", "@babel/plugin-syntax-object-rest-spread@^7.8.0", "@babel/plugin-syntax-object-rest-spread@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz#60e225edcbd98a640332a2e72dd3e66f1af55871"
   integrity sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
@@ -687,6 +960,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-transform-arrow-functions@^7.0.0":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.18.6.tgz#19063fcf8771ec7b31d742339dac62433d0611fe"
+  integrity sha512-9S9X9RUefzrsHZmKMbDXxweEH+YlE8JJEuat9FdvW9Qh1cw7W64jELCtWNkPBPX5En45uy28KGvA/AySqUh8CQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
+
 "@babel/plugin-transform-arrow-functions@^7.12.1", "@babel/plugin-transform-arrow-functions@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.14.5.tgz#f7187d9588a768dd080bf4c9ffe117ea62f7862a"
@@ -703,6 +983,13 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/helper-remap-async-to-generator" "^7.14.5"
 
+"@babel/plugin-transform-block-scoped-functions@^7.0.0":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.18.6.tgz#9187bf4ba302635b9d70d986ad70f038726216a8"
+  integrity sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
+
 "@babel/plugin-transform-block-scoped-functions@^7.12.1", "@babel/plugin-transform-block-scoped-functions@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.14.5.tgz#e48641d999d4bc157a67ef336aeb54bc44fd3ad4"
@@ -710,12 +997,34 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-transform-block-scoping@^7.0.0":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.19.4.tgz#315d70f68ce64426db379a3d830e7ac30be02e9b"
+  integrity sha512-934S2VLLlt2hRJwPf4MczaOr4hYF0z+VKPwqTNxyKX7NthTiPfhuKFWQZHXRM0vh/wo/VyXB3s4bZUNA08l+tQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.19.0"
+
 "@babel/plugin-transform-block-scoping@^7.12.1", "@babel/plugin-transform-block-scoping@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.14.5.tgz#8cc63e61e50f42e078e6f09be775a75f23ef9939"
   integrity sha512-LBYm4ZocNgoCqyxMLoOnwpsmQ18HWTQvql64t3GvMUzLQrNoV1BDG0lNftC8QKYERkZgCCT/7J5xWGObGAyHDw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-transform-classes@^7.0.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.19.0.tgz#0e61ec257fba409c41372175e7c1e606dc79bb20"
+  integrity sha512-YfeEE9kCjqTS9IitkgfJuxjcEtLUHMqa8yUJ6zdz8vR7hKuo6mOy2C05P0F1tdMmDCeuyidKnlrw/iTppHcr2A==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-compilation-targets" "^7.19.0"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.19.0"
+    "@babel/helper-optimise-call-expression" "^7.18.6"
+    "@babel/helper-plugin-utils" "^7.19.0"
+    "@babel/helper-replace-supers" "^7.18.9"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    globals "^11.1.0"
 
 "@babel/plugin-transform-classes@^7.12.1", "@babel/plugin-transform-classes@^7.14.5":
   version "7.14.5"
@@ -730,12 +1039,26 @@
     "@babel/helper-split-export-declaration" "^7.14.5"
     globals "^11.1.0"
 
+"@babel/plugin-transform-computed-properties@^7.0.0":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.18.9.tgz#2357a8224d402dad623caf6259b611e56aec746e"
+  integrity sha512-+i0ZU1bCDymKakLxn5srGHrsAPRELC2WIbzwjLhHW9SIE1cPYkLCL0NlnXMZaM1vhfgA2+M7hySk42VBvrkBRw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.9"
+
 "@babel/plugin-transform-computed-properties@^7.12.1", "@babel/plugin-transform-computed-properties@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.14.5.tgz#1b9d78987420d11223d41195461cc43b974b204f"
   integrity sha512-pWM+E4283UxaVzLb8UBXv4EIxMovU4zxT1OPnpHJcmnvyY9QbPPTKZfEj31EUvG3/EQRbYAGaYEUZ4yWOBC2xg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-transform-destructuring@^7.0.0":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.19.4.tgz#46890722687b9b89e1369ad0bd8dc6c5a3b4319d"
+  integrity sha512-t0j0Hgidqf0aM86dF8U+vXYReUgJnlv4bZLsyoPnwZNrGY+7/38o8YjaELrvHeVfTZao15kjR0PVv0nju2iduA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.19.0"
 
 "@babel/plugin-transform-destructuring@^7.12.1", "@babel/plugin-transform-destructuring@^7.14.7":
   version "7.14.7"
@@ -775,12 +1098,36 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-flow" "^7.12.1"
 
+"@babel/plugin-transform-flow-strip-types@^7.0.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.19.0.tgz#e9e8606633287488216028719638cbbb2f2dde8f"
+  integrity sha512-sgeMlNaQVbCSpgLSKP4ZZKfsJVnFnNQlUSk6gPYzR/q7tzCgQF2t8RBKAP6cKJeZdveei7Q7Jm527xepI8lNLg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.19.0"
+    "@babel/plugin-syntax-flow" "^7.18.6"
+
+"@babel/plugin-transform-for-of@^7.0.0":
+  version "7.18.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.18.8.tgz#6ef8a50b244eb6a0bdbad0c7c61877e4e30097c1"
+  integrity sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
+
 "@babel/plugin-transform-for-of@^7.12.1", "@babel/plugin-transform-for-of@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.14.5.tgz#dae384613de8f77c196a8869cbf602a44f7fc0eb"
   integrity sha512-CfmqxSUZzBl0rSjpoQSFoR9UEj3HzbGuGNL21/iFTmjb5gFggJp3ph0xR1YBhexmLoKRHzgxuFvty2xdSt6gTA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-transform-function-name@^7.0.0":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.18.9.tgz#cc354f8234e62968946c61a46d6365440fc764e0"
+  integrity sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==
+  dependencies:
+    "@babel/helper-compilation-targets" "^7.18.9"
+    "@babel/helper-function-name" "^7.18.9"
+    "@babel/helper-plugin-utils" "^7.18.9"
 
 "@babel/plugin-transform-function-name@^7.12.1", "@babel/plugin-transform-function-name@^7.14.5":
   version "7.14.5"
@@ -790,12 +1137,26 @@
     "@babel/helper-function-name" "^7.14.5"
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-transform-literals@^7.0.0":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.18.9.tgz#72796fdbef80e56fba3c6a699d54f0de557444bc"
+  integrity sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.9"
+
 "@babel/plugin-transform-literals@^7.12.1", "@babel/plugin-transform-literals@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.14.5.tgz#41d06c7ff5d4d09e3cf4587bd3ecf3930c730f78"
   integrity sha512-ql33+epql2F49bi8aHXxvLURHkxJbSmMKl9J5yHqg4PLtdE6Uc48CH1GS6TQvZ86eoB/ApZXwm7jlA+B3kra7A==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-transform-member-expression-literals@^7.0.0":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.18.6.tgz#ac9fdc1a118620ac49b7e7a5d2dc177a1bfee88e"
+  integrity sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
 
 "@babel/plugin-transform-member-expression-literals@^7.12.1", "@babel/plugin-transform-member-expression-literals@^7.14.5":
   version "7.14.5"
@@ -811,6 +1172,16 @@
   dependencies:
     "@babel/helper-module-transforms" "^7.14.5"
     "@babel/helper-plugin-utils" "^7.14.5"
+    babel-plugin-dynamic-import-node "^2.3.3"
+
+"@babel/plugin-transform-modules-commonjs@^7.0.0":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.18.6.tgz#afd243afba166cca69892e24a8fd8c9f2ca87883"
+  integrity sha512-Qfv2ZOWikpvmedXQJDSbxNqy7Xr/j2Y8/KfijM0iJyKkBTmWuvCA1yeH1yDM7NJhBW/2aXxeucLj6i80/LAJ/Q==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.18.6"
+    "@babel/helper-plugin-utils" "^7.18.6"
+    "@babel/helper-simple-access" "^7.18.6"
     babel-plugin-dynamic-import-node "^2.3.3"
 
 "@babel/plugin-transform-modules-commonjs@^7.12.1", "@babel/plugin-transform-modules-commonjs@^7.14.5":
@@ -856,6 +1227,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
+"@babel/plugin-transform-object-super@^7.0.0":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.18.6.tgz#fb3c6ccdd15939b6ff7939944b51971ddc35912c"
+  integrity sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
+    "@babel/helper-replace-supers" "^7.18.6"
+
 "@babel/plugin-transform-object-super@^7.12.1", "@babel/plugin-transform-object-super@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.14.5.tgz#d0b5faeac9e98597a161a9cf78c527ed934cdc45"
@@ -864,12 +1243,26 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/helper-replace-supers" "^7.14.5"
 
+"@babel/plugin-transform-parameters@^7.0.0", "@babel/plugin-transform-parameters@^7.18.8":
+  version "7.18.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.18.8.tgz#ee9f1a0ce6d78af58d0956a9378ea3427cccb48a"
+  integrity sha512-ivfbE3X2Ss+Fj8nnXvKJS6sjRG4gzwPMsP+taZC+ZzEGjAYlvENixmt1sZ5Ca6tWls+BlKSGKPJ6OOXvXCbkFg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
+
 "@babel/plugin-transform-parameters@^7.12.1", "@babel/plugin-transform-parameters@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.14.5.tgz#49662e86a1f3ddccac6363a7dfb1ff0a158afeb3"
   integrity sha512-Tl7LWdr6HUxTmzQtzuU14SqbgrSKmaR77M0OKyq4njZLQTPfOvzblNKyNkGwOfEFCEx7KeYHQHDI0P3F02IVkA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-transform-property-literals@^7.0.0":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.18.6.tgz#e22498903a483448e94e032e9bbb9c5ccbfc93a3"
+  integrity sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
 
 "@babel/plugin-transform-property-literals@^7.12.1", "@babel/plugin-transform-property-literals@^7.14.5":
   version "7.14.5"
@@ -891,6 +1284,13 @@
   integrity sha512-cAzB+UzBIrekfYxyLlFqf/OagTvHLcVBb5vpouzkYkBclRPraiygVnafvAoipErZLI8ANv8Ecn6E/m5qPXD26w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-transform-react-display-name@^7.0.0":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.18.6.tgz#8b1125f919ef36ebdfff061d664e266c666b9415"
+  integrity sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
 
 "@babel/plugin-transform-react-display-name@^7.12.1", "@babel/plugin-transform-react-display-name@^7.14.5":
   version "7.14.5"
@@ -919,6 +1319,17 @@
   integrity sha512-1TpSDnD9XR/rQ2tzunBVPThF5poaYT9GqP+of8fAtguYuI/dm2RkrMBDemsxtY0XBzvW7nXjYM0hRyKX9QYj7Q==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-transform-react-jsx@^7.0.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.19.0.tgz#b3cbb7c3a00b92ec8ae1027910e331ba5c500eb9"
+  integrity sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-module-imports" "^7.18.6"
+    "@babel/helper-plugin-utils" "^7.19.0"
+    "@babel/plugin-syntax-jsx" "^7.18.6"
+    "@babel/types" "^7.19.0"
 
 "@babel/plugin-transform-react-jsx@^7.12.1", "@babel/plugin-transform-react-jsx@^7.14.5":
   version "7.14.5"
@@ -975,12 +1386,27 @@
     babel-plugin-polyfill-regenerator "^0.2.2"
     semver "^6.3.0"
 
+"@babel/plugin-transform-shorthand-properties@^7.0.0":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.18.6.tgz#6d6df7983d67b195289be24909e3f12a8f664dc9"
+  integrity sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.6"
+
 "@babel/plugin-transform-shorthand-properties@^7.12.1", "@babel/plugin-transform-shorthand-properties@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.14.5.tgz#97f13855f1409338d8cadcbaca670ad79e091a58"
   integrity sha512-xLucks6T1VmGsTB+GWK5Pl9Jl5+nRXD1uoFdA5TSO6xtiNjtXTjKkmPdFXVLGlK5A2/or/wQMKfmQ2Y0XJfn5g==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-transform-spread@^7.0.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.19.0.tgz#dd60b4620c2fec806d60cfaae364ec2188d593b6"
+  integrity sha512-RsuMk7j6n+r752EtzyScnWkQyuJdli6LdO5Klv8Yx0OfPVTcQkIUfS8clx5e9yHXzlnhOZF3CbQ8C2uP5j074w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.19.0"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.18.9"
 
 "@babel/plugin-transform-spread@^7.12.1", "@babel/plugin-transform-spread@^7.14.6":
   version "7.14.6"
@@ -996,6 +1422,13 @@
   integrity sha512-Z7F7GyvEMzIIbwnziAZmnSNpdijdr4dWt+FJNBnBLz5mwDFkqIXU9wmBcWWad3QeJF5hMTkRe4dAq2sUZiG+8A==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-transform-template-literals@^7.0.0":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.18.9.tgz#04ec6f10acdaa81846689d63fae117dd9c243a5e"
+  integrity sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.9"
 
 "@babel/plugin-transform-template-literals@^7.12.1", "@babel/plugin-transform-template-literals@^7.14.5":
   version "7.14.5"
@@ -1245,6 +1678,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.0.0":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.4.tgz#a42f814502ee467d55b38dd1c256f53a7b885c78"
+  integrity sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.1", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.1", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.8.tgz#7119a56f421018852694290b9f9148097391b446"
@@ -1268,6 +1708,15 @@
     "@babel/parser" "^7.14.5"
     "@babel/types" "^7.14.5"
 
+"@babel/template@^7.18.10":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
+  integrity sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/parser" "^7.18.10"
+    "@babel/types" "^7.18.10"
+
 "@babel/traverse@^7.1.0", "@babel/traverse@^7.12.1", "@babel/traverse@^7.13.0", "@babel/traverse@^7.14.5", "@babel/traverse@^7.14.8", "@babel/traverse@^7.4.5", "@babel/traverse@^7.7.0":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.8.tgz#c0253f02677c5de1a8ff9df6b0aacbec7da1a8ce"
@@ -1283,12 +1732,37 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.14.0", "@babel/traverse@^7.16.8", "@babel/traverse@^7.19.0", "@babel/traverse@^7.19.1", "@babel/traverse@^7.19.3", "@babel/traverse@^7.19.4":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.19.4.tgz#f117820e18b1e59448a6c1fa9d0ff08f7ac459a8"
+  integrity sha512-w3K1i+V5u2aJUOXBFFC5pveFLmtq1s3qcdDNC2qRI6WPBQIDaKFqXxDEqDO/h1dQ3HjsZoZMyIy6jGLq0xtw+g==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.19.4"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.19.0"
+    "@babel/helper-hoist-variables" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/parser" "^7.19.4"
+    "@babel/types" "^7.19.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.6", "@babel/types@^7.14.5", "@babel/types@^7.14.8", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.8.tgz#38109de8fcadc06415fbd9b74df0065d4d41c728"
   integrity sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.8"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.16.8", "@babel/types@^7.18.10", "@babel/types@^7.18.13", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.19.0", "@babel/types@^7.19.3", "@babel/types@^7.19.4":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.19.4.tgz#0dd5c91c573a202d600490a35b33246fed8a41c7"
+  integrity sha512-M5LK7nAeS6+9j7hAq+b3fQs+pNfUtTGq+yFFfHnauFA8zQtLRfmuipmsKDKKLuyG+wC8ABW43A153YNawNTEtw==
+  dependencies:
+    "@babel/helper-string-parser" "^7.19.4"
+    "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -1325,6 +1799,13 @@
     sha.js "^2.4.11"
     stream-browserify "^3.0.0"
     util "^0.12.4"
+
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
 
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
@@ -2649,10 +3130,359 @@
   dependencies:
     assemblyscript "0.19.10"
 
+"@graphql-codegen/cli@^2.13.7":
+  version "2.13.7"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/cli/-/cli-2.13.7.tgz#53566cbba37e4c9d7e89d7c35a91e3fbf6bed988"
+  integrity sha512-Rpk4WWrDgkDoVELftBr7/74MPiYmCITEF2+AWmyZZ2xzaC9cO2PqzZ+OYDEBNWD6UEk0RrIfVSa+slDKjhY59w==
+  dependencies:
+    "@babel/generator" "^7.18.13"
+    "@babel/template" "^7.18.10"
+    "@babel/types" "^7.18.13"
+    "@graphql-codegen/core" "2.6.2"
+    "@graphql-codegen/plugin-helpers" "^2.6.2"
+    "@graphql-tools/apollo-engine-loader" "^7.3.6"
+    "@graphql-tools/code-file-loader" "^7.3.1"
+    "@graphql-tools/git-loader" "^7.2.1"
+    "@graphql-tools/github-loader" "^7.3.6"
+    "@graphql-tools/graphql-file-loader" "^7.5.0"
+    "@graphql-tools/json-file-loader" "^7.4.1"
+    "@graphql-tools/load" "^7.7.1"
+    "@graphql-tools/prisma-loader" "^7.2.7"
+    "@graphql-tools/url-loader" "^7.13.2"
+    "@graphql-tools/utils" "^8.9.0"
+    "@whatwg-node/fetch" "^0.3.0"
+    ansi-escapes "^4.3.1"
+    chalk "^4.1.0"
+    chokidar "^3.5.2"
+    cosmiconfig "^7.0.0"
+    cosmiconfig-typescript-loader "4.1.1"
+    debounce "^1.2.0"
+    detect-indent "^6.0.0"
+    graphql-config "4.3.6"
+    inquirer "^8.0.0"
+    is-glob "^4.0.1"
+    json-to-pretty-yaml "^1.2.2"
+    listr2 "^4.0.5"
+    log-symbols "^4.0.0"
+    mkdirp "^1.0.4"
+    shell-quote "^1.7.3"
+    string-env-interpolation "^1.0.1"
+    ts-log "^2.2.3"
+    tslib "^2.4.0"
+    yaml "^1.10.0"
+    yargs "^17.0.0"
+
+"@graphql-codegen/core@2.6.2":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/core/-/core-2.6.2.tgz#29c766d2e9e5a3deeeb4f1728c1f7b1aca054a22"
+  integrity sha512-58T5yf9nEfAhDwN1Vz1hImqpdJ/gGpCGUaroQ5tqskZPf7eZYYVkEXbtqRZZLx1MCCKwjWX4hMtTPpHhwKCkng==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^2.6.2"
+    "@graphql-tools/schema" "^9.0.0"
+    "@graphql-tools/utils" "^8.8.0"
+    tslib "~2.4.0"
+
+"@graphql-codegen/fragment-matcher@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/fragment-matcher/-/fragment-matcher-3.3.1.tgz#6ab4a9813fdaf9fb93bef8e13286ef3781228466"
+  integrity sha512-FpIDBmnbWYS50f0FdB1l8qPNi1i+IKkp3bhzT14rnLMjll+dzn1Lux5evuth+3USkS9dn2zGrzGh44j6svrpgQ==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^2.6.2"
+    tslib "~2.4.0"
+
+"@graphql-codegen/plugin-helpers@^2.6.2":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.7.1.tgz#de999bdf8a1485f6f3c4c5f21cfb038e99d67e3e"
+  integrity sha512-wpEShhwbQp8pqXolnSCNaj0pU91LbuBvYHpYqm96TUqyeKQYAYRVmw3JIt0g8UQpKYhg8lYIDwWdcINOYqkGLg==
+  dependencies:
+    "@graphql-tools/utils" "^8.8.0"
+    change-case-all "1.0.14"
+    common-tags "1.8.2"
+    import-from "4.0.0"
+    lodash "~4.17.0"
+    tslib "~2.4.0"
+
+"@graphql-codegen/schema-ast@^2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/schema-ast/-/schema-ast-2.5.1.tgz#ce030ae6de5dacd745848009ba0ca18c9c30910c"
+  integrity sha512-tewa5DEKbglWn7kYyVBkh3J8YQ5ALqAMVmZwiVFIGOao5u66nd+e4HuFqp0u+Jpz4SJGGi0ap/oFrEvlqLjd2A==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^2.6.2"
+    "@graphql-tools/utils" "^8.8.0"
+    tslib "~2.4.0"
+
+"@graphql-codegen/typed-document-node@^2.3.4":
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typed-document-node/-/typed-document-node-2.3.4.tgz#33d06c60f7e4e08ded8e9064f6871a42c3383af7"
+  integrity sha512-dIuyr//qNpaPbC1y8KGRMorhqzQ4Xmiry4OexOc/zDmUxpeQOnk+cmXNtBVk6bk2J6vTEZmhKdsfvXD8JoO7fA==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^2.6.2"
+    "@graphql-codegen/visitor-plugin-common" "2.12.2"
+    auto-bind "~4.0.0"
+    change-case-all "1.0.14"
+    tslib "~2.4.0"
+
+"@graphql-codegen/typescript-operations@^2.5.4":
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-operations/-/typescript-operations-2.5.4.tgz#e0513b5529ebc6eec0acade7f9f0838bdee997aa"
+  integrity sha512-+IA0ouGC6GZiCyvWMyzLc6K8i+oG/DjWLY0q4kc9nqBPRi8rsiYzMq/VHVtXCWxNZiGQhkjwpqNaDsqoVhOiUg==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^2.6.2"
+    "@graphql-codegen/typescript" "^2.7.4"
+    "@graphql-codegen/visitor-plugin-common" "2.12.2"
+    auto-bind "~4.0.0"
+    tslib "~2.4.0"
+
+"@graphql-codegen/typescript@^2.7.4":
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-2.7.4.tgz#46c1fac63ae1b487efe73db6531f1db5e5198fe0"
+  integrity sha512-mjoE3KqmAaBUSlCuKb2WDot3+CTfdJ9eKIcWsDFubPTNdZE0Z8mLoATmVryx8NOBjDtPU/ZziI0rYEGOR4qpAw==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^2.6.2"
+    "@graphql-codegen/schema-ast" "^2.5.1"
+    "@graphql-codegen/visitor-plugin-common" "2.12.2"
+    auto-bind "~4.0.0"
+    tslib "~2.4.0"
+
+"@graphql-codegen/visitor-plugin-common@2.12.2":
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.12.2.tgz#70eefed5567dbec6d289b05047b04bc9faae428e"
+  integrity sha512-UZJxY3mWwaM7yii7mSbl6Rxb6sJlpwGZc3QAs2Yd8MnYjXFPTBR0OO6aBTr9xuftl0pYwHu/pVK7vTPNnVmPww==
+  dependencies:
+    "@graphql-codegen/plugin-helpers" "^2.6.2"
+    "@graphql-tools/optimize" "^1.3.0"
+    "@graphql-tools/relay-operation-optimizer" "^6.5.0"
+    "@graphql-tools/utils" "^8.8.0"
+    auto-bind "~4.0.0"
+    change-case-all "1.0.14"
+    dependency-graph "^0.11.0"
+    graphql-tag "^2.11.0"
+    parse-filepath "^1.0.2"
+    tslib "~2.4.0"
+
+"@graphql-tools/apollo-engine-loader@^7.3.6":
+  version "7.3.13"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-7.3.13.tgz#090bf03a99a5aaf8580826125346cb7441b54d94"
+  integrity sha512-fr2TcA9fM+H81ymdtyDaocZ/Ua4Vhhf1IvpQoPpuEUwLorREd86N8VORUEIBvEdJ1b7Bz7NqwL3RnM5m9KXftA==
+  dependencies:
+    "@ardatan/sync-fetch" "0.0.1"
+    "@graphql-tools/utils" "8.12.0"
+    "@whatwg-node/fetch" "^0.4.0"
+    tslib "^2.4.0"
+
+"@graphql-tools/batch-execute@8.5.6":
+  version "8.5.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/batch-execute/-/batch-execute-8.5.6.tgz#476c2f9af1c302567e798d63063f1a2dfaad754a"
+  integrity sha512-33vMvVDLBKsNJVNhcySVXF+zkcRL/GRs1Lt+MxygrYCypcAPpFm+amE2y9vOCFufuaKExIX7Lonnmxu19vPzaQ==
+  dependencies:
+    "@graphql-tools/utils" "8.12.0"
+    dataloader "2.1.0"
+    tslib "^2.4.0"
+    value-or-promise "1.0.11"
+
+"@graphql-tools/code-file-loader@^7.3.1":
+  version "7.3.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/code-file-loader/-/code-file-loader-7.3.6.tgz#3e6bdd4dc93c592be3d6fbcc2c2bad1228ca0f8d"
+  integrity sha512-PNWWSwSuQAqANerDwS0zdQ5FPipirv75TjjzBHnY+6AF/WvKq5sQiUQheA2P7B+MZc/KdQ7h/JAGMQOhKNVA+Q==
+  dependencies:
+    "@graphql-tools/graphql-tag-pluck" "7.3.6"
+    "@graphql-tools/utils" "8.12.0"
+    globby "^11.0.3"
+    tslib "^2.4.0"
+    unixify "^1.0.0"
+
+"@graphql-tools/delegate@9.0.8":
+  version "9.0.8"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/delegate/-/delegate-9.0.8.tgz#aa792f419a041de0c6341eaecf9694cf6f16f76f"
+  integrity sha512-h+Uce0Np0eKj7wILOvlffRQ9jEQ4KelNXfqG8A2w+2sO2P6CbKsR7bJ4ch9lcUdCBbZ4Wg6L/K+1C4NRFfzbNw==
+  dependencies:
+    "@graphql-tools/batch-execute" "8.5.6"
+    "@graphql-tools/schema" "9.0.4"
+    "@graphql-tools/utils" "8.12.0"
+    dataloader "2.1.0"
+    tslib "~2.4.0"
+    value-or-promise "1.0.11"
+
+"@graphql-tools/git-loader@^7.2.1":
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/git-loader/-/git-loader-7.2.6.tgz#0227a99a6daf4fedac6d172726966110bb7299ef"
+  integrity sha512-QA94Gjp70xcdIYUbZDIm8fnuDN0IvoIIVVU+lXQemoV+vDeJKIjrP9tfOTjVDPIDXQnCYswvu9HLe8BlEApQYw==
+  dependencies:
+    "@graphql-tools/graphql-tag-pluck" "7.3.6"
+    "@graphql-tools/utils" "8.12.0"
+    is-glob "4.0.3"
+    micromatch "^4.0.4"
+    tslib "^2.4.0"
+    unixify "^1.0.0"
+
+"@graphql-tools/github-loader@^7.3.6":
+  version "7.3.13"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/github-loader/-/github-loader-7.3.13.tgz#16d7b90b5409591fa10106bd54581b2cbcbd498f"
+  integrity sha512-4RTjdtdtQC+n9LJMKpBThQGD3LnpeLVjU2A7BoVuKR+NQPJtcUzzuD6dXeYm5RiOMOQUsPGxQWKhJenW20aLUg==
+  dependencies:
+    "@ardatan/sync-fetch" "0.0.1"
+    "@graphql-tools/graphql-tag-pluck" "7.3.6"
+    "@graphql-tools/utils" "8.12.0"
+    "@whatwg-node/fetch" "^0.4.0"
+    tslib "^2.4.0"
+
+"@graphql-tools/graphql-file-loader@^7.3.7", "@graphql-tools/graphql-file-loader@^7.5.0":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.5.5.tgz#d8afb391282e3dc33005df04bdec8488e4ab101d"
+  integrity sha512-OL+7qO1S66TpMK7OGz8Ag2WL08HlxKxrObVSDlxzWbSubWuXM5v959XscYAKRf6daYcVpkfNvO37QjflL9mjhg==
+  dependencies:
+    "@graphql-tools/import" "6.7.6"
+    "@graphql-tools/utils" "8.12.0"
+    globby "^11.0.3"
+    tslib "^2.4.0"
+    unixify "^1.0.0"
+
+"@graphql-tools/graphql-tag-pluck@7.3.6":
+  version "7.3.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.3.6.tgz#27029ef9e8d7f4bcf8dd8627fb93bd45cc0215fd"
+  integrity sha512-qULgqsOGKY1/PBqmP7fJZqbCg/TzPHKB9Wl51HGA9QjGymrzmrH5EjvsC8RtgdubF8yuTTVVFTz1lmSQ7RPssQ==
+  dependencies:
+    "@babel/parser" "^7.16.8"
+    "@babel/traverse" "^7.16.8"
+    "@babel/types" "^7.16.8"
+    "@graphql-tools/utils" "8.12.0"
+    tslib "^2.4.0"
+
+"@graphql-tools/import@6.7.6":
+  version "6.7.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/import/-/import-6.7.6.tgz#9bc0bb304a6fcc43aa2c9177631670b1fdfb2115"
+  integrity sha512-WtUyiO2qCaK/H4u81zAw/NbBvCOzwKl4N+Vl+FqrFCzYobscwL6x6roePyoXM1O3+JJIIn3CETv4kg4kwxaBVw==
+  dependencies:
+    "@graphql-tools/utils" "8.12.0"
+    resolve-from "5.0.0"
+    tslib "^2.4.0"
+
+"@graphql-tools/json-file-loader@^7.3.7", "@graphql-tools/json-file-loader@^7.4.1":
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/json-file-loader/-/json-file-loader-7.4.6.tgz#d4135c3e15491eda653f58ed89efbd5e21d0b1b8"
+  integrity sha512-34AfjCitO4NtJ5AcXYLcFF3GDsMVTycrljSaBA2t1d7B4bMPtREDphKXLMc/Uf2zW6IW1i1sZZyrcmArPy1Z8A==
+  dependencies:
+    "@graphql-tools/utils" "8.12.0"
+    globby "^11.0.3"
+    tslib "^2.4.0"
+    unixify "^1.0.0"
+
+"@graphql-tools/load@^7.5.5", "@graphql-tools/load@^7.7.1":
+  version "7.7.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/load/-/load-7.7.7.tgz#0d6fb0804177658f609562982a6a68e008073ca0"
+  integrity sha512-IpI2672zcoAX4FLjcH5kvHc7eqjPyLP1svrIcZKQenv0GRS6dW0HI9E5UCBs0y/yy8yW6s+SvpmNsfIlkMj3Kw==
+  dependencies:
+    "@graphql-tools/schema" "9.0.4"
+    "@graphql-tools/utils" "8.12.0"
+    p-limit "3.1.0"
+    tslib "^2.4.0"
+
+"@graphql-tools/merge@8.3.6", "@graphql-tools/merge@^8.2.6":
+  version "8.3.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.3.6.tgz#97a936d4c8e8f935e58a514bb516c476437b5b2c"
+  integrity sha512-uUBokxXi89bj08P+iCvQk3Vew4vcfL5ZM6NTylWi8PIpoq4r5nJ625bRuN8h2uubEdRiH8ntN9M4xkd/j7AybQ==
+  dependencies:
+    "@graphql-tools/utils" "8.12.0"
+    tslib "^2.4.0"
+
+"@graphql-tools/optimize@^1.3.0":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/optimize/-/optimize-1.3.1.tgz#29407991478dbbedc3e7deb8c44f46acb4e9278b"
+  integrity sha512-5j5CZSRGWVobt4bgRRg7zhjPiSimk+/zIuColih8E8DxuFOaJ+t0qu7eZS5KXWBkjcd4BPNuhUPpNlEmHPqVRQ==
+  dependencies:
+    tslib "^2.4.0"
+
+"@graphql-tools/prisma-loader@^7.2.7":
+  version "7.2.24"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/prisma-loader/-/prisma-loader-7.2.24.tgz#46b4acf5a4b52aeff00f1f29a39ccc55f8933dd1"
+  integrity sha512-CRQvoraCIcQa44RMSF3EpzLedouR9SSLC6ylFEHCFf2b8r1EfbK5NOdLL1V9znOjjapI6/oJURlFWdldcAaMgg==
+  dependencies:
+    "@graphql-tools/url-loader" "7.16.4"
+    "@graphql-tools/utils" "8.12.0"
+    "@types/js-yaml" "^4.0.0"
+    "@types/json-stable-stringify" "^1.0.32"
+    "@types/jsonwebtoken" "^8.5.0"
+    chalk "^4.1.0"
+    debug "^4.3.1"
+    dotenv "^16.0.0"
+    graphql-request "^5.0.0"
+    http-proxy-agent "^5.0.0"
+    https-proxy-agent "^5.0.0"
+    isomorphic-fetch "^3.0.0"
+    js-yaml "^4.0.0"
+    json-stable-stringify "^1.0.1"
+    jsonwebtoken "^8.5.1"
+    lodash "^4.17.20"
+    scuid "^1.1.0"
+    tslib "^2.4.0"
+    yaml-ast-parser "^0.0.43"
+
+"@graphql-tools/relay-operation-optimizer@^6.5.0":
+  version "6.5.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.5.6.tgz#b0df15fc78fac95000f8d1b1419490822fe79f22"
+  integrity sha512-2KjaWYxD/NC6KtckbDEAbN46QO+74d1SBaZQ26qQjWhyoAjon12xlMW4HWxHEN0d0xuz0cnOVUVc+t4wVXePUg==
+  dependencies:
+    "@ardatan/relay-compiler" "12.0.0"
+    "@graphql-tools/utils" "8.12.0"
+    tslib "^2.4.0"
+
+"@graphql-tools/schema@9.0.4", "@graphql-tools/schema@^9.0.0":
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-9.0.4.tgz#1a74608b57abf90fae6fd929d25e5482c57bc05d"
+  integrity sha512-B/b8ukjs18fq+/s7p97P8L1VMrwapYc3N2KvdG/uNThSazRRn8GsBK0Nr+FH+mVKiUfb4Dno79e3SumZVoHuOQ==
+  dependencies:
+    "@graphql-tools/merge" "8.3.6"
+    "@graphql-tools/utils" "8.12.0"
+    tslib "^2.4.0"
+    value-or-promise "1.0.11"
+
+"@graphql-tools/url-loader@7.16.4", "@graphql-tools/url-loader@^7.13.2", "@graphql-tools/url-loader@^7.9.7":
+  version "7.16.4"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/url-loader/-/url-loader-7.16.4.tgz#d27787ef9f35fe71b456c067c3a1759b1ecd76a8"
+  integrity sha512-7yGrJJNcqVQIplCyVLk7tW2mAgYyZ06FRmCBnzw3B61+aIjFavrm6YlnKkhdqYSYyFmIbVcigdP3vkoYIu23TA==
+  dependencies:
+    "@ardatan/sync-fetch" "0.0.1"
+    "@graphql-tools/delegate" "9.0.8"
+    "@graphql-tools/utils" "8.12.0"
+    "@graphql-tools/wrap" "9.2.3"
+    "@types/ws" "^8.0.0"
+    "@whatwg-node/fetch" "^0.4.0"
+    dset "^3.1.2"
+    extract-files "^11.0.0"
+    graphql-ws "^5.4.1"
+    isomorphic-ws "^5.0.0"
+    meros "^1.1.4"
+    tslib "^2.4.0"
+    value-or-promise "^1.0.11"
+    ws "^8.3.0"
+
+"@graphql-tools/utils@8.12.0", "@graphql-tools/utils@^8.6.5", "@graphql-tools/utils@^8.8.0", "@graphql-tools/utils@^8.9.0":
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.12.0.tgz#243bc4f5fc2edbc9e8fd1038189e57d837cbe31f"
+  integrity sha512-TeO+MJWGXjUTS52qfK4R8HiPoF/R7X+qmgtOYd8DTH0l6b+5Y/tlg5aGeUJefqImRq7nvi93Ms40k/Uz4D5CWw==
+  dependencies:
+    tslib "^2.4.0"
+
+"@graphql-tools/wrap@9.2.3":
+  version "9.2.3"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/wrap/-/wrap-9.2.3.tgz#70f7602aed9781fbc860cea64a918636599883be"
+  integrity sha512-aiLjcAuUwcvA1mF25c7KFDPXEdQDpo6bTDyAMCSlFXpF4T01hoxLERmfmbRmsmy/dP80ZB31a+t70aspVdqZSA==
+  dependencies:
+    "@graphql-tools/delegate" "9.0.8"
+    "@graphql-tools/schema" "9.0.4"
+    "@graphql-tools/utils" "8.12.0"
+    tslib "^2.4.0"
+    value-or-promise "1.0.11"
+
 "@graphql-typed-document-node/core@^3.0.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
   integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
+
+"@graphql-typed-document-node/core@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
+  integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
 
 "@hapi/address@2.x.x":
   version "2.1.4"
@@ -2723,6 +3553,11 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
+
+"@iarna/toml@^2.2.5":
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
+  integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
 
 "@internationalized/date@^3.0.0":
   version "3.0.0"
@@ -2975,6 +3810,54 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@jridgewell/gen-mapping@^0.1.0":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"
+  integrity sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==
+  dependencies:
+    "@jridgewell/set-array" "^1.0.0"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/gen-mapping@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
+  integrity sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==
+  dependencies:
+    "@jridgewell/set-array" "^1.0.1"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
+"@jridgewell/resolve-uri@3.1.0", "@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
+  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
+
+"@jridgewell/set-array@^1.0.0", "@jridgewell/set-array@^1.0.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
+  integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
+
+"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.14"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
+  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/trace-mapping@^0.3.9":
+  version "0.3.17"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
+  integrity sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==
+  dependencies:
+    "@jridgewell/resolve-uri" "3.1.0"
+    "@jridgewell/sourcemap-codec" "1.4.14"
+
 "@json-rpc-tools/provider@^1.5.5":
   version "1.7.6"
   resolved "https://registry.yarnpkg.com/@json-rpc-tools/provider/-/provider-1.7.6.tgz#8a17c34c493fa892632e278fd9331104e8491ec6"
@@ -3141,6 +4024,33 @@
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.4.2.tgz#4e889c9c66e736f7de189a53f8ba5b8d789425c2"
   integrity sha512-NyJV7sJgoGYqbtNUWgzzOGW4T6rR19FmX1IJgXGdapGPWsuMelGJn9h03nos0iqfforCbCB0iYIR0MtIuIFLLw==
+
+"@peculiar/asn1-schema@^2.1.6":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.3.0.tgz#5368416eb336138770c692ffc2bab119ee3ae917"
+  integrity sha512-DtNLAG4vmDrdSJFPe7rypkcj597chNQL7u+2dBtYo5mh7VW2+im6ke+O0NVr8W1f4re4C3F71LhoMb0Yxqa48Q==
+  dependencies:
+    asn1js "^3.0.5"
+    pvtsutils "^1.3.2"
+    tslib "^2.4.0"
+
+"@peculiar/json-schema@^1.1.12":
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/@peculiar/json-schema/-/json-schema-1.1.12.tgz#fe61e85259e3b5ba5ad566cb62ca75b3d3cd5339"
+  integrity sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==
+  dependencies:
+    tslib "^2.0.0"
+
+"@peculiar/webcrypto@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/webcrypto/-/webcrypto-1.4.0.tgz#f941bd95285a0f8a3d2af39ccda5197b80cd32bf"
+  integrity sha512-U58N44b2m3OuTgpmKgf0LPDOmP3bhwNz01vAnj1mBwxBASRhptWYK+M3zG+HBkDqGQM+bFsoIihTW8MdmPXEqg==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.1.6"
+    "@peculiar/json-schema" "^1.1.12"
+    pvtsutils "^1.3.2"
+    tslib "^2.4.0"
+    webcrypto-core "^1.7.4"
 
 "@pedrouid/environment@^1.0.1":
   version "1.0.1"
@@ -4801,6 +5711,31 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@tootallnate/once@2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
+  integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
+  integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
+
 "@typechain/ethers-v5@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@typechain/ethers-v5/-/ethers-v5-2.0.0.tgz#cd3ca1590240d587ca301f4c029b67bfccd08810"
@@ -4978,15 +5913,32 @@
   resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.7.tgz#226a9e31680835a6188e887f3988e60c04d3f6a3"
   integrity sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==
 
+"@types/js-yaml@^4.0.0":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.5.tgz#738dd390a6ecc5442f35e7f03fa1431353f7e138"
+  integrity sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==
+
 "@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8":
   version "7.0.8"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.8.tgz#edf1bf1dbf4e04413ca8e5b17b3b7d7d54b59818"
   integrity sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==
 
+"@types/json-stable-stringify@^1.0.32":
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/@types/json-stable-stringify/-/json-stable-stringify-1.0.34.tgz#c0fb25e4d957e0ee2e497c1f553d7f8bb668fd75"
+  integrity sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
+
+"@types/jsonwebtoken@^8.5.0":
+  version "8.5.9"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz#2c064ecb0b3128d837d2764aa0b117b0ff6e4586"
+  integrity sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/level-errors@*":
   version "3.0.0"
@@ -5288,6 +6240,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/ws@^8.0.0":
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"
+  integrity sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "20.2.1"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.1.tgz#3b9ce2489919d9e4fea439b76916abc34b2df129"
@@ -5502,6 +6461,14 @@
   dependencies:
     "@uniswap/lib" "1.1.1"
     "@uniswap/v2-core" "1.0.0"
+
+"@urql/core@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@urql/core/-/core-3.0.3.tgz#da054babb4d4aed26dc4503806b310ba6dd6eea1"
+  integrity sha512-raQP51ERNtg5BvlN8x8mHVRvk4K0ugWQ69n53BdkjKpXVV5kuWp7trnwriGv1fQKa8HuiGNSCfyslUucc0OVQg==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    wonka "^6.0.0"
 
 "@vanilla-extract/css@1.7.0":
   version "1.7.0"
@@ -6024,6 +6991,35 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
+"@whatwg-node/fetch@^0.3.0":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@whatwg-node/fetch/-/fetch-0.3.2.tgz#da4323795c26c135563ba01d49dc16037bec4287"
+  integrity sha512-Bs5zAWQs0tXsLa4mRmLw7Psps1EN78vPtgcLpw3qPY8s6UYPUM67zFZ9cy+7tZ64PXhfwzxJn+m7RH2Lq48RNQ==
+  dependencies:
+    "@peculiar/webcrypto" "^1.4.0"
+    abort-controller "^3.0.0"
+    busboy "^1.6.0"
+    event-target-polyfill "^0.0.3"
+    form-data-encoder "^1.7.1"
+    formdata-node "^4.3.1"
+    node-fetch "^2.6.7"
+    undici "^5.8.0"
+    web-streams-polyfill "^3.2.0"
+
+"@whatwg-node/fetch@^0.4.0":
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/@whatwg-node/fetch/-/fetch-0.4.7.tgz#4cbcda3ba93d5ae15ab823aae5869eae4a0cb14b"
+  integrity sha512-+oKDMGtmUJ7H37VDL5U2Vdk+ZxsIypZxO2q6y42ytu6W3PL6OIIUYZGliNqQgWtCdtxOZ9WPQvbIAuiLpnLlUw==
+  dependencies:
+    "@peculiar/webcrypto" "^1.4.0"
+    abort-controller "^3.0.0"
+    busboy "^1.6.0"
+    form-data-encoder "^1.7.1"
+    formdata-node "^4.3.1"
+    node-fetch "^2.6.7"
+    undici "^5.10.0"
+    web-streams-polyfill "^3.2.0"
+
 "@wojtekmaj/date-utils@^1.0.0", "@wojtekmaj/date-utils@^1.0.2", "@wojtekmaj/date-utils@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@wojtekmaj/date-utils/-/date-utils-1.0.3.tgz#2dcfd92881425c5923e429c2aec86fb3609032a1"
@@ -6218,6 +7214,11 @@ acorn-walk@^7.0.0, acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^6.4.1:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
@@ -6233,7 +7234,7 @@ acorn@^8.2.4:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.4.1.tgz#56c36251fc7cabc7096adc18f05afe814321a28c"
   integrity sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==
 
-acorn@^8.7.1:
+acorn@^8.4.1, acorn@^8.7.1:
   version "8.8.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
   integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
@@ -6654,6 +7655,11 @@ archy@^1.0.0:
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
 
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
 arg@^5.0.1, arg@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
@@ -6919,6 +7925,15 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
+asn1js@^3.0.1, asn1js@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/asn1js/-/asn1js-3.0.5.tgz#5ea36820443dbefb51cc7f88a2ebb5b462114f38"
+  integrity sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==
+  dependencies:
+    pvtsutils "^1.3.2"
+    pvutils "^1.1.3"
+    tslib "^2.4.0"
+
 assemblyscript@0.19.10:
   version "0.19.10"
   resolved "https://registry.yarnpkg.com/assemblyscript/-/assemblyscript-0.19.10.tgz#7ede6d99c797a219beb4fa4614c3eab9e6343c8e"
@@ -7064,6 +8079,11 @@ authereum@^0.1.14:
     uuidv4 "6.0.6"
     web3-provider-engine "15.0.4"
     web3-utils "1.2.1"
+
+auto-bind@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/auto-bind/-/auto-bind-4.0.0.tgz#e3589fc6c2da8f7ca43ba9f84fa52a744fc997fb"
+  integrity sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==
 
 autoprefixer@^10.2.4:
   version "10.3.1"
@@ -7496,6 +8516,11 @@ babel-plugin-syntax-trailing-function-commas@^6.22.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
   integrity sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=
 
+babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
+  integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
+
 babel-plugin-transform-async-to-generator@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761"
@@ -7786,6 +8811,39 @@ babel-preset-env@^1.7.0:
     invariant "^2.2.2"
     semver "^5.3.0"
 
+babel-preset-fbjs@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-fbjs/-/babel-preset-fbjs-3.4.0.tgz#38a14e5a7a3b285a3f3a86552d650dca5cf6111c"
+  integrity sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==
+  dependencies:
+    "@babel/plugin-proposal-class-properties" "^7.0.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
+    "@babel/plugin-syntax-class-properties" "^7.0.0"
+    "@babel/plugin-syntax-flow" "^7.0.0"
+    "@babel/plugin-syntax-jsx" "^7.0.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
+    "@babel/plugin-transform-arrow-functions" "^7.0.0"
+    "@babel/plugin-transform-block-scoped-functions" "^7.0.0"
+    "@babel/plugin-transform-block-scoping" "^7.0.0"
+    "@babel/plugin-transform-classes" "^7.0.0"
+    "@babel/plugin-transform-computed-properties" "^7.0.0"
+    "@babel/plugin-transform-destructuring" "^7.0.0"
+    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
+    "@babel/plugin-transform-for-of" "^7.0.0"
+    "@babel/plugin-transform-function-name" "^7.0.0"
+    "@babel/plugin-transform-literals" "^7.0.0"
+    "@babel/plugin-transform-member-expression-literals" "^7.0.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.0.0"
+    "@babel/plugin-transform-object-super" "^7.0.0"
+    "@babel/plugin-transform-parameters" "^7.0.0"
+    "@babel/plugin-transform-property-literals" "^7.0.0"
+    "@babel/plugin-transform-react-display-name" "^7.0.0"
+    "@babel/plugin-transform-react-jsx" "^7.0.0"
+    "@babel/plugin-transform-shorthand-properties" "^7.0.0"
+    "@babel/plugin-transform-spread" "^7.0.0"
+    "@babel/plugin-transform-template-literals" "^7.0.0"
+    babel-plugin-syntax-trailing-function-commas "^7.0.0-beta.0"
+
 babel-preset-jest@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz#747872b1171df032252426586881d62d31798fee"
@@ -8058,7 +9116,7 @@ bl@^3.0.0:
   dependencies:
     readable-stream "^3.0.1"
 
-bl@^4.0.3:
+bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
   integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
@@ -8380,6 +9438,16 @@ browserslist@^4.20.3:
     node-releases "^2.0.6"
     update-browserslist-db "^1.0.4"
 
+browserslist@^4.21.3:
+  version "4.21.4"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.4.tgz#e7496bbc67b9e39dd0f98565feccdcb0d4ff6987"
+  integrity sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==
+  dependencies:
+    caniuse-lite "^1.0.30001400"
+    electron-to-chromium "^1.4.251"
+    node-releases "^2.0.6"
+    update-browserslist-db "^1.0.9"
+
 bs58@^4.0.0, bs58@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
@@ -8425,6 +9493,11 @@ buffer-alloc@^1.2.0:
   dependencies:
     buffer-alloc-unsafe "^1.1.0"
     buffer-fill "^1.0.0"
+
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
 
 buffer-equal@^1.0.0:
   version "1.0.0"
@@ -8524,6 +9597,13 @@ burner-provider@^1.0.38:
     ethereumjs-wallet "^0.6.3"
     ethers "^4.0.46"
     web3-provider-engine "^15.0.7"
+
+busboy@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
+  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
+  dependencies:
+    streamsearch "^1.1.0"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -8662,7 +9742,7 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-camel-case@^4.1.1:
+camel-case@^4.1.1, camel-case@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
   integrity sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
@@ -8733,6 +9813,20 @@ caniuse-lite@^1.0.30001332, caniuse-lite@^1.0.30001335, caniuse-lite@^1.0.300013
   version "1.0.30001370"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001370.tgz#0a30d4f20d38b9e108cc5ae7cc62df9fe66cd5ba"
   integrity sha512-3PDmaP56wz/qz7G508xzjx8C+MC2qEm4SYhSEzC9IBROo+dGXFWRuaXkWti0A9tuI00g+toiriVqxtWMgl350g==
+
+caniuse-lite@^1.0.30001400:
+  version "1.0.30001419"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001419.tgz#3542722d57d567c8210d5e4d0f9f17336b776457"
+  integrity sha512-aFO1r+g6R7TW+PNQxKzjITwLOyDhVRLjW0LcwS/HCZGUUKTGNp9+IwLC4xyDSZBygVL/mxaFR3HIV6wEKQuSzw==
+
+capital-case@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/capital-case/-/capital-case-1.0.4.tgz#9d130292353c9249f6b00fa5852bee38a717e669"
+  integrity sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case-first "^2.0.2"
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -8827,6 +9921,40 @@ chalk@^4.1.1, chalk@^4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+change-case-all@1.0.14:
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/change-case-all/-/change-case-all-1.0.14.tgz#bac04da08ad143278d0ac3dda7eccd39280bfba1"
+  integrity sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==
+  dependencies:
+    change-case "^4.1.2"
+    is-lower-case "^2.0.2"
+    is-upper-case "^2.0.2"
+    lower-case "^2.0.2"
+    lower-case-first "^2.0.2"
+    sponge-case "^1.0.1"
+    swap-case "^2.0.2"
+    title-case "^3.0.3"
+    upper-case "^2.0.2"
+    upper-case-first "^2.0.2"
+
+change-case@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/change-case/-/change-case-4.1.2.tgz#fedfc5f136045e2398c0410ee441f95704641e12"
+  integrity sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==
+  dependencies:
+    camel-case "^4.1.2"
+    capital-case "^1.0.4"
+    constant-case "^3.0.4"
+    dot-case "^3.0.4"
+    header-case "^2.0.4"
+    no-case "^3.0.4"
+    param-case "^3.0.4"
+    pascal-case "^3.1.2"
+    path-case "^3.0.4"
+    sentence-case "^3.0.4"
+    snake-case "^3.0.4"
+    tslib "^2.0.3"
 
 char-regex@^1.0.2:
   version "1.0.2"
@@ -9040,6 +10168,11 @@ cli-spinners@^2.2.0:
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.6.0.tgz#36c7dc98fb6a9a76bd6238ec3f77e2425627e939"
   integrity sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==
 
+cli-spinners@^2.5.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.7.0.tgz#f815fd30b5f9eaac02db604c7a231ed7cb2f797a"
+  integrity sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==
+
 cli-table3@^0.5.0, cli-table3@^0.5.1, cli-table3@~0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.5.1.tgz#0252372d94dfc40dbd8df06005f48f31f656f202"
@@ -9050,10 +10183,23 @@ cli-table3@^0.5.0, cli-table3@^0.5.1, cli-table3@~0.5.0:
   optionalDependencies:
     colors "^1.1.2"
 
+cli-truncate@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
+  integrity sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==
+  dependencies:
+    slice-ansi "^3.0.0"
+    string-width "^4.2.0"
+
 cli-width@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
   integrity sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==
+
+cli-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
+  integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -9098,6 +10244,15 @@ cliui@^7.0.2:
   dependencies:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
 clone-buffer@^1.0.0:
@@ -9254,6 +10409,11 @@ colorette@^1.2.1, colorette@^1.2.2:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
+colorette@^2.0.16:
+  version "2.0.19"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
+  integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
+
 colors@^1.1.2, colors@^1.3.3, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
@@ -9294,6 +10454,11 @@ commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
+common-tags@1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
+  integrity sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==
 
 common-tags@^1.8.0:
   version "1.8.0"
@@ -9378,6 +10543,15 @@ console-browserify@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
   integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
+
+constant-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/constant-case/-/constant-case-3.0.4.tgz#3b84a9aeaf4cf31ec45e6bf5de91bdfb0589faf1"
+  integrity sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case "^2.0.2"
 
 constants-browserify@^1.0.0:
   version "1.0.0"
@@ -9532,6 +10706,18 @@ cors@^2.8.1:
     object-assign "^4"
     vary "^1"
 
+cosmiconfig-toml-loader@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig-toml-loader/-/cosmiconfig-toml-loader-1.0.0.tgz#0681383651cceff918177debe9084c0d3769509b"
+  integrity sha512-H/2gurFWVi7xXvCyvsWRLCMekl4tITJcX0QEsDMpzxtuxDyM59xLatYNg4s/k9AA/HdtCYfj2su8mgA0GSDLDA==
+  dependencies:
+    "@iarna/toml" "^2.2.5"
+
+cosmiconfig-typescript-loader@4.1.1, cosmiconfig-typescript-loader@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.1.1.tgz#38dd3578344038dae40fdf09792bc2e9df529f78"
+  integrity sha512-9DHpa379Gp0o0Zefii35fcmuuin6q92FnLDffzdZ0l9tVd3nEobG3O+MZ06+kuBvFTSVScvNb/oHA13Nd4iipg==
+
 cosmiconfig@6.0.0, cosmiconfig@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"
@@ -9542,6 +10728,17 @@ cosmiconfig@6.0.0, cosmiconfig@^6.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.7.2"
+
+cosmiconfig@7.0.1, cosmiconfig@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
+  integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.2.1"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.10.0"
 
 cosmiconfig@^5.0.0:
   version "5.2.1"
@@ -9557,17 +10754,6 @@ cosmiconfig@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.0.tgz#ef9b44d773959cae63ddecd122de23853b60f8d3"
   integrity sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==
-  dependencies:
-    "@types/parse-json" "^4.0.0"
-    import-fresh "^3.2.1"
-    parse-json "^5.0.0"
-    path-type "^4.0.0"
-    yaml "^1.10.0"
-
-cosmiconfig@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
-  integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
   dependencies:
     "@types/parse-json" "^4.0.0"
     import-fresh "^3.2.1"
@@ -9613,6 +10799,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-fetch@^2.1.0, cross-fetch@^2.1.1:
   version "2.2.5"
@@ -10005,6 +11196,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+dataloader@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.1.0.tgz#c69c538235e85e7ac6c6c444bae8ecabf5de9df7"
+  integrity sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==
+
 date-fns@2.x:
   version "2.23.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.23.0.tgz#4e886c941659af0cf7b30fafdd1eaa37e88788a9"
@@ -10019,6 +11215,11 @@ dayjs@1.x:
   version "1.10.6"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.6.tgz#288b2aa82f2d8418a6c9d4df5898c0737ad02a63"
   integrity sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw==
+
+debounce@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
+  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
@@ -10266,6 +11467,11 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+dependency-graph@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.11.0.tgz#ac0ce7ed68a54da22165a85e97a01d53f5eb2e27"
+  integrity sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==
+
 des.js@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
@@ -10300,6 +11506,11 @@ detect-indent@^4.0.0:
   integrity sha1-920GQ1LN9Docts5hnE7jqUdd4gg=
   dependencies:
     repeating "^2.0.0"
+
+detect-indent@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
+  integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -10347,6 +11558,11 @@ diff@3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -10566,6 +11782,11 @@ dotenv@8.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
+dotenv@^16.0.0:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
 dotenv@^8.2.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
@@ -10591,6 +11812,11 @@ dset@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.0.tgz#23feb6df93816ea452566308b1374d6e869b0d7b"
   integrity sha512-7xTQ5DzyE59Nn+7ZgXDXjKAGSGmXZHqttMVVz1r4QNfmGpyj+cm2YtI3II0c/+4zS4a9yq2mBhgdeq2QnpcYlw==
+
+dset@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.2.tgz#89c436ca6450398396dc6538ea00abc0c54cd45a"
+  integrity sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==
 
 duplexer3@^0.1.4:
   version "0.1.4"
@@ -10628,6 +11854,13 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -10661,6 +11894,11 @@ electron-to-chromium@^1.4.188:
   version "1.4.199"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.199.tgz#e0384fde79fdda89880e8be58196a9153e04db3b"
   integrity sha512-WIGME0Cs7oob3mxsJwHbeWkH0tYkIE/sjkJ8ML2BYmuRcjhRl/q5kVDXG7W9LOOKwzPU5M0LBlXRq9rlSgnNlg==
+
+electron-to-chromium@^1.4.251:
+  version "1.4.282"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.282.tgz#02af3fd6051e97ac3388a4b11d455bc1ca49838f"
+  integrity sha512-Dki0WhHNh/br/Xi1vAkueU5mtIc9XLHcMKB6tNfQKk+kPG0TEUjRh5QEMAUbRp30/rYNMFD1zKKvbVzwq/4wmg==
 
 elliptic@6.5.2:
   version "6.5.2"
@@ -12289,6 +13527,11 @@ ethjs-util@0.1.6, ethjs-util@^0.1.3:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
 
+event-target-polyfill@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/event-target-polyfill/-/event-target-polyfill-0.0.3.tgz#ed373295f3b257774b5d75afb2599331d9f3406c"
+  integrity sha512-ZMc6UuvmbinrCk4RzGyVmRyIsAyxMRlp4CqSrcQRO8Dy0A9ldbiRy5kdtBj4OtP7EClGdqGfIqo9JmOClMsGLQ==
+
 event-target-shim@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
@@ -12523,6 +13766,16 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+extract-files@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-11.0.0.tgz#b72d428712f787eef1f5193aff8ab5351ca8469a"
+  integrity sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==
+
+extract-files@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-9.0.0.tgz#8a7744f2437f81f5ed3250ed9f1550de902fe54a"
+  integrity sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -12666,6 +13919,24 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fbjs-css-vars@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
+  integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
+
+fbjs@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-3.0.4.tgz#e1871c6bd3083bac71ff2da868ad5067d37716c6"
+  integrity sha512-ucV0tDODnGV3JCnnkmoszb5lf4bNpzjv80K41wd4k798Etq+UYD0y0TIfalLjZoKgjive6/adkRnszwapiDgBQ==
+  dependencies:
+    cross-fetch "^3.1.5"
+    fbjs-css-vars "^1.0.0"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.30"
+
 fetch-ponyfill@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz#ae3ce5f732c645eab87e4ae8793414709b239893"
@@ -12682,6 +13953,13 @@ figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
   integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
+figures@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
+  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   dependencies:
     escape-string-regexp "^1.0.5"
 
@@ -12961,6 +14239,11 @@ fork-ts-checker-webpack-plugin@4.1.6:
     tapable "^1.0.0"
     worker-rpc "^0.1.0"
 
+form-data-encoder@^1.7.1:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-1.7.2.tgz#1f1ae3dccf58ed4690b86d87e4f57c654fbab040"
+  integrity sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==
+
 form-data@^2.2.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
@@ -12996,6 +14279,14 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+formdata-node@^4.3.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/formdata-node/-/formdata-node-4.4.1.tgz#23f6a5cb9cb55315912cbec4ff7b0f59bbd191e2"
+  integrity sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==
+  dependencies:
+    node-domexception "1.0.0"
+    web-streams-polyfill "4.0.0-beta.3"
 
 fortmatic@^2.2.1:
   version "2.2.1"
@@ -13676,6 +14967,25 @@ graphiql@^1.4.7:
     graphql-language-service "^3.1.6"
     markdown-it "^12.2.0"
 
+graphql-config@4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-4.3.6.tgz#908ef03d6670c3068e51fe2e84e10e3e0af220b6"
+  integrity sha512-i7mAPwc0LAZPnYu2bI8B6yXU5820Wy/ArvmOseDLZIu0OU1UTULEuexHo6ZcHXeT9NvGGaUPQZm8NV3z79YydA==
+  dependencies:
+    "@graphql-tools/graphql-file-loader" "^7.3.7"
+    "@graphql-tools/json-file-loader" "^7.3.7"
+    "@graphql-tools/load" "^7.5.5"
+    "@graphql-tools/merge" "^8.2.6"
+    "@graphql-tools/url-loader" "^7.9.7"
+    "@graphql-tools/utils" "^8.6.5"
+    cosmiconfig "7.0.1"
+    cosmiconfig-toml-loader "1.0.0"
+    cosmiconfig-typescript-loader "^4.0.0"
+    minimatch "4.2.1"
+    string-env-interpolation "1.0.1"
+    ts-node "^10.8.1"
+    tslib "^2.4.0"
+
 graphql-language-service-interface@^2.9.0, graphql-language-service-interface@^2.9.1:
   version "2.9.1"
   resolved "https://registry.yarnpkg.com/graphql-language-service-interface/-/graphql-language-service-interface-2.9.1.tgz#be0b11b06b78730ea9d250e0e2290e7ed9c8d283"
@@ -13721,6 +15031,23 @@ graphql-language-service@^3.1.6:
     graphql-language-service-types "^1.8.3"
     graphql-language-service-utils "^2.6.0"
 
+graphql-request@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-5.0.0.tgz#7504a807d0e11be11a3c448e900f0cc316aa18ef"
+  integrity sha512-SpVEnIo2J5k2+Zf76cUkdvIRaq5FMZvGQYnA4lUWYbc99m+fHh4CZYRRO/Ff4tCLQ613fzCm3SiDT64ubW5Gyw==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    cross-fetch "^3.1.5"
+    extract-files "^9.0.0"
+    form-data "^3.0.0"
+
+graphql-tag@^2.11.0:
+  version "2.12.6"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
+  integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
+  dependencies:
+    tslib "^2.1.0"
+
 graphql-tag@^2.12.0, graphql-tag@^2.4.2:
   version "2.12.5"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.5.tgz#5cff974a67b417747d05c8d9f5f3cb4495d0db8f"
@@ -13733,6 +15060,11 @@ graphql-ws@^4.9.0:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-4.9.0.tgz#5cfd8bb490b35e86583d8322f5d5d099c26e365c"
   integrity sha512-sHkK9+lUm20/BGawNEWNtVAeJzhZeBg21VmvmLoT5NdGVeZWv5PdIhkcayQIAgjSyyQ17WMKmbDijIPG2On+Ag==
 
+graphql-ws@^5.4.1:
+  version "5.11.2"
+  resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.11.2.tgz#d5e0acae8b4d4a4cf7be410a24135cfcefd7ddc0"
+  integrity sha512-4EiZ3/UXYcjm+xFGP544/yW1+DVI8ZpKASFbzrV5EDTFWJp0ZvLl4Dy2fSZAzz9imKp5pZMIcjB0x/H69Pv/6w==
+
 graphql@^15.3.0:
   version "15.5.1"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.1.tgz#f2f84415d8985e7b84731e7f3536f8bb9d383aad"
@@ -13742,6 +15074,11 @@ graphql@^15.5.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.6.0.tgz#e69323c6a9780a1a4b9ddf7e35ca8904bb04df02"
   integrity sha512-WJR872Zlc9hckiEPhXgyUftXH48jp2EjO5tgBBOyNMRJZ9fviL2mJBD6CAysk6N5S0r9BTs09Qk39nnJBkvOXQ==
+
+graphql@^16.6.0:
+  version "16.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
+  integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
 
 growl@1.10.5:
   version "1.10.5"
@@ -14088,6 +15425,14 @@ he@1.2.0, he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+header-case@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/header-case/-/header-case-2.0.4.tgz#5a42e63b55177349cf405beb8d775acabb92c063"
+  integrity sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==
+  dependencies:
+    capital-case "^1.0.4"
+    tslib "^2.0.3"
+
 heap@0.2.6:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.6.tgz#087e1f10b046932fc8594dd9e6d378afc9d1e5ac"
@@ -14302,6 +15647,15 @@ http-proxy-agent@^4.0.1:
     agent-base "6"
     debug "4"
 
+http-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
+  integrity sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==
+  dependencies:
+    "@tootallnate/once" "2"
+    agent-base "6"
+    debug "4"
+
 http-proxy-middleware@0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz#183c7dc4aa1479150306498c210cdaf96080a43a"
@@ -14460,6 +15814,11 @@ immutable@^4.0.0-rc.12:
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.14.tgz#29ba96631ec10867d1348515ac4e6bdba462f071"
   integrity sha512-pfkvmRKJSoW7JFx0QeYlAmT+kNYvn5j0u7bnpNq4N2RCvHSTlLT208G8jgaquNe+Q8kCPHKOSpxJkyvLDpYq0w==
 
+immutable@~3.7.6:
+  version "3.7.6"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
+  integrity sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw==
+
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
@@ -14482,6 +15841,11 @@ import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
+
+import-from@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/import-from/-/import-from-4.0.0.tgz#2710b8d66817d232e16f4166e319248d3d5492e2"
+  integrity sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==
 
 import-from@^2.1.0:
   version "2.1.0"
@@ -14594,6 +15958,27 @@ inquirer@^6.2.2:
     string-width "^2.1.0"
     strip-ansi "^5.1.0"
     through "^2.3.6"
+
+inquirer@^8.0.0:
+  version "8.2.4"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.4.tgz#ddbfe86ca2f67649a67daa6f1051c128f684f0b4"
+  integrity sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.1"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    ora "^5.4.1"
+    run-async "^2.4.0"
+    rxjs "^7.5.5"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+    wrap-ansi "^7.0.0"
 
 interface-datastore@^6.0.2:
   version "6.1.0"
@@ -15152,6 +16537,13 @@ is-generator-function@^1.0.7:
   dependencies:
     has-tostringtag "^1.0.0"
 
+is-glob@4.0.3, is-glob@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
+  dependencies:
+    is-extglob "^2.1.1"
+
 is-glob@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
@@ -15163,13 +16555,6 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
-  dependencies:
-    is-extglob "^2.1.1"
-
-is-glob@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
-  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
 
@@ -15208,6 +16593,13 @@ is-ipfs@~0.6.1:
     multiaddr "^7.2.1"
     multibase "~0.6.0"
     multihashes "~0.4.13"
+
+is-lower-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-lower-case/-/is-lower-case-2.0.2.tgz#1c0884d3012c841556243483aa5d522f47396d2a"
+  integrity sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==
+  dependencies:
+    tslib "^2.0.3"
 
 is-module@^1.0.0:
   version "1.0.0"
@@ -15424,6 +16816,18 @@ is-unc-path@^1.0.0:
   dependencies:
     unc-path-regex "^0.1.2"
 
+is-unicode-supported@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
+  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
+is-upper-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-upper-case/-/is-upper-case-2.0.2.tgz#f1105ced1fe4de906a5f39553e7d3803fd804649"
+  integrity sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==
+  dependencies:
+    tslib "^2.0.3"
+
 is-url@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
@@ -15539,6 +16943,11 @@ isomorphic-ws@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
   integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
+
+isomorphic-ws@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz#e5529148912ecb9b451b46ed44d53dae1ce04bbf"
+  integrity sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -16148,7 +17557,7 @@ js-yaml@^3.13.1, js-yaml@^3.14.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^4.1.0:
+js-yaml@^4.0.0, js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
@@ -16307,6 +17716,14 @@ json-text-sequence@~0.1.0:
   dependencies:
     delimit-stream "0.1.0"
 
+json-to-pretty-yaml@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz#f4cd0bd0a5e8fe1df25aaf5ba118b099fd992d5b"
+  integrity sha512-rvm6hunfCcqegwYaG5T4yKJWxc9FXFgBVrcTZ4XfSVRwa5HA/Xs+vB/Eo9treYYHCeNM0nrSUr82V/M31Urc7A==
+  dependencies:
+    remedial "^1.0.7"
+    remove-trailing-spaces "^1.0.6"
+
 json2mq@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/json2mq/-/json2mq-0.2.0.tgz#b637bd3ba9eabe122c83e9720483aeb10d2c904a"
@@ -16337,6 +17754,11 @@ json5@^2.1.2, json5@^2.2.0:
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   dependencies:
     minimist "^1.2.5"
+
+json5@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
+  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
 jsonfile@^2.1.0:
   version "2.4.0"
@@ -16370,6 +17792,22 @@ jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
+
+jsonwebtoken@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -16416,6 +17854,23 @@ just-map-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/just-map-keys/-/just-map-keys-1.1.0.tgz#9663c9f971ba46e17f2b05e66fec81149375f230"
   integrity sha512-oNKi+4y7fr8lXnhKYpBbCkiwHRVkAnx0VDkCeTDtKKMzGr1Lz1Yym+RSieKUTKim68emC5Yxrb4YmiF9STDO+g==
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 keccak256@^1.0.0:
   version "1.0.3"
@@ -16902,6 +18357,20 @@ linkifyjs@^3.0.5:
   resolved "https://registry.yarnpkg.com/linkifyjs/-/linkifyjs-3.0.5.tgz#99e51a3a0c0e232fcb63ebb89eea3ff923378f34"
   integrity sha512-1Y9XQH65eQKA9p2xtk+zxvnTeQBG7rdAXSkUG97DmuI/Xhji9uaUzaWxRj6rf9YC0v8KKHkxav7tnLX82Sz5Fg==
 
+listr2@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-4.0.5.tgz#9dcc50221583e8b4c71c43f9c7dfd0ef546b75d5"
+  integrity sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==
+  dependencies:
+    cli-truncate "^2.1.0"
+    colorette "^2.0.16"
+    log-update "^4.0.0"
+    p-map "^4.0.0"
+    rfdc "^1.3.0"
+    rxjs "^7.5.5"
+    through "^2.3.8"
+    wrap-ansi "^7.0.0"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -17023,10 +18492,35 @@ lodash.flatten@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
+
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
 
 lodash.kebabcase@^4.1.1:
   version "4.1.1"
@@ -17053,7 +18547,7 @@ lodash.merge@^4.4.0, lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.once@^4.1.1:
+lodash.once@^4.0.0, lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
@@ -17153,7 +18647,7 @@ lodash@4.17.20:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
-"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.7.0:
+"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.7.0, lodash@~4.17.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -17165,6 +18659,14 @@ log-symbols@3.0.0, log-symbols@^3.0.0:
   dependencies:
     chalk "^2.4.2"
 
+log-symbols@^4.0.0, log-symbols@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
+  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
+  dependencies:
+    chalk "^4.1.0"
+    is-unicode-supported "^0.1.0"
+
 log-update@3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/log-update/-/log-update-3.3.0.tgz#3b0501815123f66cb33f300e3dac2a2b6ad3fdf5"
@@ -17173,6 +18675,16 @@ log-update@3.3.0:
     ansi-escapes "^3.2.0"
     cli-cursor "^2.1.0"
     wrap-ansi "^5.0.0"
+
+log-update@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-4.0.0.tgz#589ecd352471f2a1c0c570287543a64dfd20e0a1"
+  integrity sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==
+  dependencies:
+    ansi-escapes "^4.3.0"
+    cli-cursor "^3.1.0"
+    slice-ansi "^4.0.0"
+    wrap-ansi "^6.2.0"
 
 loglevel@^1.6.8:
   version "1.7.1"
@@ -17213,6 +18725,13 @@ loud-rejection@^1.0.0:
   dependencies:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
+
+lower-case-first@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lower-case-first/-/lower-case-first-2.0.2.tgz#64c2324a2250bf7c37c5901e76a5b5309301160b"
+  integrity sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==
+  dependencies:
+    tslib "^2.0.3"
 
 lower-case@^2.0.2:
   version "2.0.2"
@@ -17307,6 +18826,11 @@ make-dir@^3.0.0, make-dir@^3.0.2:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 make-event-props@^1.1.0:
   version "1.3.0"
@@ -17714,6 +19238,13 @@ minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-4.2.1.tgz#40d9d511a46bdc4e563c22c3080cde9c0d8299b4"
+  integrity sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -18298,6 +19829,11 @@ node-addon-api@^2.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
 
+node-domexception@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-environment-flags@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/node-environment-flags/-/node-environment-flags-1.0.6.tgz#a30ac13621f6f7d674260a54dede048c3982c088"
@@ -18311,7 +19847,7 @@ node-fetch@2.6.1, node-fetch@^2.3.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
-node-fetch@2.6.7, "node-fetch@https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz":
+node-fetch@2.6.7, node-fetch@^2.6.7, "node-fetch@https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz":
   version "2.6.7"
   resolved "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz#1b5d62978f2ed07b99444f64f0df39f960a6d34d"
 
@@ -18514,7 +20050,7 @@ nth-check@^2.0.0:
   dependencies:
     boolbase "^1.0.0"
 
-nullthrows@^1.0.0:
+nullthrows@^1.0.0, nullthrows@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
   integrity sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==
@@ -18879,6 +20415,21 @@ ora@^4.0.0:
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
 
+ora@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
+  integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
+  dependencies:
+    bl "^4.1.0"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-spinners "^2.5.0"
+    is-interactive "^1.0.0"
+    is-unicode-supported "^0.1.0"
+    log-symbols "^4.1.0"
+    strip-ansi "^6.0.0"
+    wcwidth "^1.0.1"
+
 ordered-read-streams@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz#77c0cb37c41525d64166d990ffad7ec6a0e1363e"
@@ -18963,6 +20514,13 @@ p-finally@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-2.0.1.tgz#bd6fcaa9c559a096b680806f4d657b3f0f240561"
   integrity sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==
 
+p-limit@3.1.0, p-limit@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
 p-limit@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
@@ -18976,13 +20534,6 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
   dependencies:
     p-try "^2.0.0"
-
-p-limit@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
-  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
-  dependencies:
-    yocto-queue "^0.1.0"
 
 p-locate@^2.0.0:
   version "2.0.0"
@@ -19055,7 +20606,7 @@ parallel-transform@^1.1.0:
     inherits "^2.0.3"
     readable-stream "^2.1.5"
 
-param-case@^3.0.3:
+param-case@^3.0.3, param-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
   integrity sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==
@@ -19091,7 +20642,7 @@ parse-duration@^1.0.0:
   resolved "https://registry.yarnpkg.com/parse-duration/-/parse-duration-1.0.2.tgz#b9aa7d3a1363cc7e8845bea8fd3baf8a11df5805"
   integrity sha512-Dg27N6mfok+ow1a2rj/nRjtCfaKrHUZV2SJpEn/s8GaVUSlf4GGRCRP1c13Hj+wfPKVMrFDqLMLITkYKgKxyyg==
 
-parse-filepath@^1.0.1:
+parse-filepath@^1.0.1, parse-filepath@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/parse-filepath/-/parse-filepath-1.0.2.tgz#a632127f53aaf3d15876f5872f3ffac763d6c891"
   integrity sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=
@@ -19209,6 +20760,14 @@ path-browserify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
   integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
+
+path-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/path-case/-/path-case-3.0.4.tgz#9168645334eb942658375c56f80b4c0cb5f82c6f"
+  integrity sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
 
 path-dirname@^1.0.0:
   version "1.0.2"
@@ -20401,6 +21960,13 @@ promise-to-callback@^1.0.0:
     is-fn "^1.0.0"
     set-immediate-shim "^1.0.1"
 
+promise@^7.1.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
+  dependencies:
+    asap "~2.0.3"
+
 promise@^8.0.0, promise@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/promise/-/promise-8.1.0.tgz#697c25c3dfe7435dd79fcd58c38a135888eaf05e"
@@ -20738,6 +22304,18 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+pvtsutils@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/pvtsutils/-/pvtsutils-1.3.2.tgz#9f8570d132cdd3c27ab7d51a2799239bf8d8d5de"
+  integrity sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==
+  dependencies:
+    tslib "^2.4.0"
+
+pvutils@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/pvutils/-/pvutils-1.1.3.tgz#f35fc1d27e7cd3dfbd39c0826d173e806a03f5a3"
+  integrity sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==
 
 q@^1.1.2:
   version "1.5.1"
@@ -22117,6 +23695,20 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+relay-runtime@12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-12.0.0.tgz#1e039282bdb5e0c1b9a7dc7f6b9a09d4f4ff8237"
+  integrity sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    fbjs "^3.0.0"
+    invariant "^2.2.4"
+
+remedial@^1.0.7:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/remedial/-/remedial-1.0.8.tgz#a5e4fd52a0e4956adbaf62da63a5a46a78c578a0"
+  integrity sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==
+
 remove-accents@0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
@@ -22143,6 +23735,11 @@ remove-trailing-separator@^1.0.1, remove-trailing-separator@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
   integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
+
+remove-trailing-spaces@^1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/remove-trailing-spaces/-/remove-trailing-spaces-1.0.8.tgz#4354d22f3236374702f58ee373168f6d6887ada7"
+  integrity sha512-O3vsMYfWighyFbTd8hk8VaSj9UAGENxAtX+//ugIst2RMk5e03h6RoIS+0ylsFxY1gvmPuAY/PO4It+gPEeySA==
 
 renderkid@^2.0.4:
   version "2.0.7"
@@ -22299,6 +23896,11 @@ resolve-dir@^1.0.0, resolve-dir@^1.0.1:
     expand-tilde "^2.0.0"
     global-modules "^1.0.0"
 
+resolve-from@5.0.0, resolve-from@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
+  integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
@@ -22308,11 +23910,6 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
-
-resolve-from@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
-  integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
 resolve-options@^1.1.0:
   version "1.1.0"
@@ -22455,6 +24052,11 @@ rework@1.0.1:
     convert-source-map "^0.3.3"
     css "^2.0.0"
 
+rfdc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
+  integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
+
 rgb-regex@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/rgb-regex/-/rgb-regex-1.0.1.tgz#c0e0d6882df0e23be254a475e8edd41915feaeb1"
@@ -22575,7 +24177,7 @@ rtl-css-js@^1.14.0:
   dependencies:
     "@babel/runtime" "^7.1.2"
 
-run-async@^2.2.0:
+run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
@@ -22605,6 +24207,13 @@ rxjs@^6.4.0, rxjs@^6.6.3:
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
+
+rxjs@^7.5.5:
+  version "7.5.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.7.tgz#2ec0d57fdc89ece220d2e702730ae8f1e49def39"
+  integrity sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==
+  dependencies:
+    tslib "^2.1.0"
 
 s3-folder-upload@^2.3.1:
   version "2.3.5"
@@ -22783,6 +24392,11 @@ scryptsy@^1.2.1:
   dependencies:
     pbkdf2 "^3.0.3"
 
+scuid@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/scuid/-/scuid-1.1.0.tgz#d3f9f920956e737a60f72d0e4ad280bf324d5dab"
+  integrity sha512-MuCAyrGZcTLfQoH2XoBlQ8C6bzwN88XT/0slOGz0pn8+gIP85BOAfYa44ZXQUTOwRwPU0QvgU+V+OSajl/59Xg==
+
 sdp@^2.12.0, sdp@^2.6.0:
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/sdp/-/sdp-2.12.0.tgz#338a106af7560c86e4523f858349680350d53b22"
@@ -22909,6 +24523,15 @@ send@0.17.1:
     on-finished "~2.3.0"
     range-parser "~1.2.1"
     statuses "~1.5.0"
+
+sentence-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-3.0.4.tgz#3645a7b8c117c787fde8702056225bb62a45131f"
+  integrity sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case-first "^2.0.2"
 
 serialize-javascript@^4.0.0:
   version "4.0.0"
@@ -23060,6 +24683,11 @@ shell-quote@1.7.2:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
+shell-quote@^1.7.3:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.4.tgz#33fe15dee71ab2a81fcbd3a52106c5cfb9fb75d8"
+  integrity sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==
+
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
@@ -23085,6 +24713,11 @@ signed-varint@^2.0.1:
   integrity sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=
   dependencies:
     varint "~5.0.0"
+
+signedsource@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/signedsource/-/signedsource-1.0.0.tgz#1ddace4981798f93bd833973803d80d52e93ad6a"
+  integrity sha512-6+eerH9fEnNmi/hyM1DXcRK3pWdoMQtlkQ+ns0ntzunjKqp5i3sKCc80ym8Fib3iaYhdJUOPdhlJWj1tvge2Ww==
 
 simple-concat@^1.0.0:
   version "1.0.1"
@@ -23127,6 +24760,15 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+slice-ansi@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787"
+  integrity sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
+
 slice-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
@@ -23135,6 +24777,14 @@ slice-ansi@^4.0.0:
     ansi-styles "^4.0.0"
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
+
+snake-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-3.0.4.tgz#4f2bbd568e9935abdfd593f34c691dadb49c452c"
+  integrity sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -23406,6 +25056,13 @@ split@0.3.1:
   dependencies:
     through "2"
 
+sponge-case@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sponge-case/-/sponge-case-1.0.1.tgz#260833b86453883d974f84854cdb63aecc5aef4c"
+  integrity sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==
+  dependencies:
+    tslib "^2.0.3"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -23581,6 +25238,11 @@ stream-to-pull-stream@^1.7.1, stream-to-pull-stream@^1.7.2:
     looper "^3.0.0"
     pull-stream "^3.2.3"
 
+streamsearch@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
+  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
+
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
@@ -23595,6 +25257,11 @@ string-convert@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
   integrity sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c=
+
+string-env-interpolation@1.0.1, string-env-interpolation@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz#ad4397ae4ac53fe6c91d1402ad6f6a52862c7152"
+  integrity sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -23635,7 +25302,7 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.0.0, string-width@^4.2.2:
+string-width@^4.0.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -24014,6 +25681,13 @@ svgo@^1.0.0, svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
+swap-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/swap-case/-/swap-case-2.0.2.tgz#671aedb3c9c137e2985ef51c51f9e98445bf70d9"
+  integrity sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==
+  dependencies:
+    tslib "^2.0.3"
+
 swarm-js@^0.1.40:
   version "0.1.40"
   resolved "https://registry.yarnpkg.com/swarm-js/-/swarm-js-0.1.40.tgz#b1bc7b6dcc76061f6c772203e004c11997e06b99"
@@ -24378,7 +26052,7 @@ through2@^3.0.0, through2@^3.0.1:
     inherits "^2.0.4"
     readable-stream "2 || 3"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.6, through@~2.3.4, through@~2.3.8:
+through@2, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8, through@~2.3.4, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -24442,6 +26116,13 @@ tippy.js@^6.3.7:
   integrity sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==
   dependencies:
     "@popperjs/core" "^2.9.0"
+
+title-case@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/title-case/-/title-case-3.0.3.tgz#bc689b46f02e411f1d1e1d081f7c3deca0489982"
+  integrity sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==
+  dependencies:
+    tslib "^2.0.3"
 
 tmp-promise@^3.0.2:
   version "3.0.2"
@@ -24658,6 +26339,30 @@ ts-invariant@^0.8.0:
   dependencies:
     tslib "^2.1.0"
 
+ts-log@^2.2.3:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/ts-log/-/ts-log-2.2.5.tgz#aef3252f1143d11047e2cb6f7cfaac7408d96623"
+  integrity sha512-PGcnJoTBnVGy6yYNFxWVNkdcAuAMstvutN9MgDJIV6L0oG8fB+ZNNy1T+wJzah8RPGor1mZuPQkVfXNDpy9eHA==
+
+ts-node@^10.8.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 ts-pnp@1.2.0, ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
@@ -24691,6 +26396,11 @@ tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
+tslib@^2.4.0, tslib@~2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tsort@0.0.1:
   version "0.0.1"
@@ -24855,6 +26565,11 @@ typical@^2.6.0, typical@^2.6.1:
   resolved "https://registry.yarnpkg.com/typical/-/typical-2.6.1.tgz#5c080e5d661cbbe38259d2e70a3c7253e873881d"
   integrity sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=
 
+ua-parser-js@^0.7.30:
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.31.tgz#649a656b191dffab4f21d5e053e27ca17cbff5c6"
+  integrity sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==
+
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
@@ -24937,6 +26652,13 @@ undertaker@^1.2.1:
     object.defaults "^1.0.0"
     object.reduce "^1.0.0"
     undertaker-registry "^1.0.0"
+
+undici@^5.10.0, undici@^5.8.0:
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.11.0.tgz#1db25f285821828fc09d3804b9e2e934ae86fc13"
+  integrity sha512-oWjWJHzFet0Ow4YZBkyiJwiK5vWqEYoH7BINzJAJOLedZ++JpAlCbUktW2GQ2DS2FpKmxD/JMtWUUWl1BtghGw==
+  dependencies:
+    busboy "^1.6.0"
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
@@ -25025,6 +26747,13 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
+unixify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unixify/-/unixify-1.0.0.tgz#3a641c8c2ffbce4da683a5c70f03a462940c2090"
+  integrity sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==
+  dependencies:
+    normalize-path "^2.1.1"
+
 unload@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
@@ -25074,10 +26803,32 @@ update-browserslist-db@^1.0.4:
     escalade "^3.1.1"
     picocolors "^1.0.0"
 
+update-browserslist-db@^1.0.9:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz#0f54b876545726f17d00cd9a2561e6dade943ff3"
+  integrity sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==
+  dependencies:
+    escalade "^3.1.1"
+    picocolors "^1.0.0"
+
 update-input-width@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/update-input-width/-/update-input-width-1.2.2.tgz#9a6a35858ae8e66fbfe0304437b23a4934fc7d37"
   integrity sha512-6QwD9ZVSXb96PxOZ01DU0DJTPwQGY7qBYgdniZKJN02Xzom2m+9J6EPxMbefskqtj4x78qbe5psDSALq9iNEYg==
+
+upper-case-first@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-2.0.2.tgz#992c3273f882abd19d1e02894cc147117f844324"
+  integrity sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==
+  dependencies:
+    tslib "^2.0.3"
+
+upper-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-2.0.2.tgz#d89810823faab1df1549b7d97a76f8662bae6f7a"
+  integrity sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==
+  dependencies:
+    tslib "^2.0.3"
 
 uri-js@^4.2.2:
   version "4.4.1"
@@ -25152,6 +26903,14 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+urql@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/urql/-/urql-3.0.3.tgz#275631f487558354e090d9ffc4ea2030bd56c34a"
+  integrity sha512-aVUAMRLdc5AOk239DxgXt6ZxTl/fEmjr7oyU5OGo8uvpqu42FkeJErzd2qBzhAQ3DyusoZIbqbBLPlnKo/yy2A==
+  dependencies:
+    "@urql/core" "^3.0.3"
+    wonka "^6.0.0"
 
 ursa-optional@~0.10.0:
   version "0.10.2"
@@ -25305,6 +27064,11 @@ uuidv4@6.0.6:
   dependencies:
     uuid "7.0.2"
 
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
+
 v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
@@ -25343,6 +27107,11 @@ value-or-function@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/value-or-function/-/value-or-function-3.0.0.tgz#1c243a50b595c1be54a754bfece8563b9ff8d813"
   integrity sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=
+
+value-or-promise@1.0.11, value-or-promise@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/value-or-promise/-/value-or-promise-1.0.11.tgz#3e90299af31dd014fe843fe309cefa7c1d94b140"
+  integrity sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==
 
 varint@^5.0.0, varint@~5.0.0:
   version "5.0.2"
@@ -25527,6 +27296,16 @@ wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+web-streams-polyfill@4.0.0-beta.3:
+  version "4.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz#2898486b74f5156095e473efe989dcf185047a38"
+  integrity sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==
+
+web-streams-polyfill@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
+  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
 
 web3-bzz@1.2.11:
   version "1.2.11"
@@ -25915,6 +27694,17 @@ web3modal@^1.9.1:
     styled-components "^5.1.1"
     tslib "^1.10.0"
 
+webcrypto-core@^1.7.4:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/webcrypto-core/-/webcrypto-core-1.7.5.tgz#c02104c953ca7107557f9c165d194c6316587ca4"
+  integrity sha512-gaExY2/3EHQlRNNNVSrbG2Cg94Rutl7fAaKILS1w8ZDhGxdFOaw6EbCfHIxPy9vt/xwp5o0VQAx9aySPF6hU1A==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.1.6"
+    "@peculiar/json-schema" "^1.1.12"
+    asn1js "^3.0.1"
+    pvtsutils "^1.3.2"
+    tslib "^2.4.0"
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -26189,6 +27979,11 @@ window-size@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
   integrity sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=
+
+wonka@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/wonka/-/wonka-6.1.0.tgz#65297ebf7031ae46d4b0c56da93950fb3ae5baaa"
+  integrity sha512-VgiMCz7BXOiDbgpVhf5iNhK7hurteY5Jv0fDJewUkY0s4fbxQD2iKqfGxNXNTwp2v3bgT8QVu2l5H7YdkZ5WIA==
 
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
@@ -26465,6 +28260,11 @@ ws@^7.4.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
+ws@^8.3.0:
+  version "8.9.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.9.0.tgz#2a994bb67144be1b53fe2d23c53c028adeb7f45e"
+  integrity sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==
+
 xhr-request-promise@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz#2d5f4b16d8c6c893be97f1a62b0ed4cf3ca5f96c"
@@ -26572,6 +28372,11 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yaml-ast-parser@^0.0.43:
+  version "0.0.43"
+  resolved "https://registry.yarnpkg.com/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz#e8a23e6fb4c38076ab92995c5dca33f3d3d7c9bb"
+  integrity sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==
+
 yaml@^1.10.0, yaml@^1.10.2, yaml@^1.5.1, yaml@^1.7.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
@@ -26620,6 +28425,11 @@ yargs-parser@^20.2.2:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
+yargs-parser@^21.0.0:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs-parser@^5.0.1:
   version "5.0.1"
@@ -26684,6 +28494,19 @@ yargs@^16.1.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
+yargs@^17.0.0:
+  version "17.6.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.0.tgz#e134900fc1f218bc230192bdec06a0a5f973e46c"
+  integrity sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.0.0"
+
 yargs@^4.7.1:
   version "4.8.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-4.8.1.tgz#c0c42924ca4aaa6b0e6da1739dfb216439f9ddc0"
@@ -26732,6 +28555,11 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
# Description

- feat: display Lens profile associated to proposal author/voter Ethereum address if it exists, its associated ENS if it exists, and fallback to the address otherwise ;

![Screenshot 2022-10-14 at 16-56-16 JokeDAO 🃏 An open-source collaborative decision-making platform](https://user-images.githubusercontent.com/15010369/195877994-c925a771-f597-4637-9f3b-1dbe67708bd8.png)

- refacto: `useContest` to remove `fetchEns`

**Important**: add `NEXT_PUBLIC_LENS_API_URL=https://api.lens.dev` to your local `.env`

## Screenshots

### Before

![Screenshot 2022-10-14 at 16-33-30 JokeDAO 🃏 An open-source collaborative decision-making platform](https://user-images.githubusercontent.com/15010369/195875167-15b93dc5-3b5d-423d-9f54-288fdb36ada2.png)

![Screenshot 2022-10-14 at 16-34-26 JokeDAO 🃏 An open-source collaborative decision-making platform](https://user-images.githubusercontent.com/15010369/195875215-00eab079-5231-447e-aaad-709775368814.png)

### After

![Screenshot 2022-10-14 at 16-41-35 JokeDAO 🃏 An open-source collaborative decision-making platform](https://user-images.githubusercontent.com/15010369/195874481-1b30f9cf-d002-4a4e-a48f-48043c90c630.png)

![Screenshot 2022-10-14 at 16-41-18 JokeDAO 🃏 An open-source collaborative decision-making platform](https://user-images.githubusercontent.com/15010369/195874502-12bab531-c607-4c37-8a1c-16c475e2bcd4.png)

## Type of change
- [x] New feature (breaking change due to refactoring)