### PR TITLE
bugfix: remove vote event cutoff race condition

### DIFF
--- a/packages/react-app-revamp/hooks/useContestEvents/index.ts
+++ b/packages/react-app-revamp/hooks/useContestEvents/index.ts
@@ -86,9 +86,20 @@ export function useContestEvents() {
   }
 
   useEffect(() => {
-    if(canUpdateVotesInRealTime === true) {
-          // Only watch VoteCast events when voting is open and we are <=1h before end of voting
-        if(contestStatus === CONTEST_STATUS.VOTING_OPEN) {
+    if (canUpdateVotesInRealTime === false) {
+      if(contestStatus === CONTEST_STATUS.COMPLETED) {
+        const contract = getContract({
+          addressOrName: asPath.split("/")[3],
+          contractInterface: DeployedContestContract.abi,
+
+        })
+        contract.removeAllListeners()
+      }
+    }
+
+    else if (canUpdateVotesInRealTime === true) {
+      // Only watch VoteCast events when voting is open and we are <=1h before end of voting
+      if(contestStatus === CONTEST_STATUS.VOTING_OPEN) {
         watchContractEvent({
           addressOrName: asPath.split("/")[3],
           contractInterface: DeployedContestContract.abi,

--- a/packages/react-app-revamp/hooks/useContestEvents/index.ts
+++ b/packages/react-app-revamp/hooks/useContestEvents/index.ts
@@ -86,15 +86,13 @@ export function useContestEvents() {
   }
 
   useEffect(() => {
-    if (canUpdateVotesInRealTime === false) {
-      if(contestStatus === CONTEST_STATUS.COMPLETED) {
-        const contract = getContract({
-          addressOrName: asPath.split("/")[3],
-          contractInterface: DeployedContestContract.abi,
+    if (canUpdateVotesInRealTime === false && contestStatus === CONTEST_STATUS.COMPLETED) {
+      const contract = getContract({
+        addressOrName: asPath.split("/")[3],
+        contractInterface: DeployedContestContract.abi,
 
-        })
-        contract.removeAllListeners()
-      }
+      });
+      contract.removeAllListeners();
     }
 
     else if (canUpdateVotesInRealTime === true) {

--- a/packages/react-app-revamp/hooks/useProposalVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useProposalVotes/index.ts
@@ -229,7 +229,17 @@ export function useProposalVotes(id: number | string) {
   }, [account?.connector]);
 
   useEffect(() => {
-    if(canUpdateVotesInRealTime === true) {
+    if(canUpdateVotesInRealTime === false) {
+      if(contestStatus === CONTEST_STATUS.COMPLETED) {
+        const contract = getContract({
+          addressOrName: asPath.split("/")[3],
+          contractInterface: DeployedContestContract.abi,
+        })
+        contract.removeAllListeners()
+      }
+    }
+
+    else if (canUpdateVotesInRealTime === true) {
       // Only watch VoteCast events when voting is open and we are <=1h before end of voting
       if(contestStatus === CONTEST_STATUS.VOTING_OPEN) {
         watchContractEvent({

--- a/packages/react-app-revamp/hooks/useProposalVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useProposalVotes/index.ts
@@ -229,14 +229,12 @@ export function useProposalVotes(id: number | string) {
   }, [account?.connector]);
 
   useEffect(() => {
-    if(canUpdateVotesInRealTime === false) {
-      if(contestStatus === CONTEST_STATUS.COMPLETED) {
-        const contract = getContract({
-          addressOrName: asPath.split("/")[3],
-          contractInterface: DeployedContestContract.abi,
-        })
-        contract.removeAllListeners()
-      }
+    if(canUpdateVotesInRealTime === false && contestStatus === CONTEST_STATUS.COMPLETED) {
+      const contract = getContract({
+        addressOrName: asPath.split("/")[3],
+        contractInterface: DeployedContestContract.abi,
+      });
+      contract.removeAllListeners();
     }
 
     else if (canUpdateVotesInRealTime === true) {


### PR DESCRIPTION
# Description
Currently, whether `VoteCast` event listeners are shut off when a contest ends is determined by a race condition on whether `canUpdateVotesInRealTime` or `contestStatus` is updated first. If the former is updated first then the listeners never get turned off, but we want to make sure that regardless of which condition updates first upon the completion of a contest, we disable these listeners as soon as one of them does.

In order to fix this, this PR adds a check to cover when `canUpdateVotesInRealTime` is `false` in the `useEffect`s that control `VoteCast` listeners.

Fixing a bug introduced in #107.

## Type of change
- [x] Bugfix