### PR TITLE
bugfix: allow and render decimals for share and payout amounts

### DIFF
--- a/packages/react-app-revamp/components/_pages/RewardsWinner/index.tsx
+++ b/packages/react-app-revamp/components/_pages/RewardsWinner/index.tsx
@@ -10,10 +10,11 @@ interface RewardsWinnerProps {
   contractRewardsModuleAddress: string;
   abiRewardsModule: any;
   chainId: number;
+  totalShares: number;
 }
 
 export const RewardsWinner = (props: RewardsWinnerProps) => {
-  const { payee, erc20Tokens, contractRewardsModuleAddress, abiRewardsModule } = props;
+  const { payee, erc20Tokens, contractRewardsModuleAddress, abiRewardsModule, totalShares } = props;
   const { asPath } = useRouter();
   const { data, isError, isLoading } = useContractRead({
     addressOrName: contractRewardsModuleAddress,
@@ -32,7 +33,7 @@ export const RewardsWinner = (props: RewardsWinnerProps) => {
           {isError && "Something went wrong, please reload the page."}
           {data && (
             <>
-            <h2 className="font-bold text-lg mb-1">Rank {`${payee}`}: wins {`${data}`}% of all rewards</h2>
+            <h2 className="font-bold text-lg mb-1">Rank {`${payee}`}: wins {`${((data.toNumber() * 100) / totalShares).toFixed(2)}`}% of all rewards</h2>
             <ul>
               <li>
                 <PayeeNativeReward

--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/Form.tsx
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/Form.tsx
@@ -1010,7 +1010,7 @@ export const Form = (props: FormProps) => {
                     }, 0);
                     const rewardPercentage = isNaN(totalRewardsAmount)
                       ? 0
-                      : Math.floor((reward.rewardTokenAmount / totalRewardsAmount) * 100);
+                      : ((reward.rewardTokenAmount / totalRewardsAmount) * 100).toFixed(2);
                     return (
                       <li className="animate-appear text-neutral-12 text-xs" key={`rank-distribution-${reward.key}`}>
                         Proposal with rank {reward.winningRank} will get{" "}

--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/useDeployContest.ts
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/useDeployContest.ts
@@ -129,7 +129,7 @@ export function useDeployContest(form: any) {
           return sumRewards + reward.rewardTokenAmount;
         }, 0);
         const rewardsShares = values.rewards.map((reward: any) =>
-          Math.floor((reward.rewardTokenAmount / totalRewardsAmount) * 100),
+          reward.rewardTokenAmount * 100000000, // be able to handle decimals
         );
 
         // Deploy the rewards module

--- a/packages/react-app-revamp/pages/contest/[chain]/[address]/rewards/index.tsx
+++ b/packages/react-app-revamp/pages/contest/[chain]/[address]/rewards/index.tsx
@@ -152,6 +152,8 @@ const Page = (props: PageProps) => {
                             contractRewardsModuleAddress={storeRewardsModule.rewardsModule.contractAddress}
                             //@ts-ignore
                             abiRewardsModule={storeRewardsModule.rewardsModule.abi}
+                            //@ts-ignore
+                            totalShares={storeRewardsModule.rewardsModule.totalShares}
                           />
                         </li>
                       ))}


### PR DESCRIPTION
This PR does 2 things:
- In order for more clarity specifies the percentage that each rank gets paid out when displaying this information to 2 decimals.
- Multiplies the reward amounts by `100000000` to get the number of shares to assign each rank in order to allow 8 decimal places to be entered for reward amounts.