### PR TITLE
bugfix: Remove event listener on tab isn't focused

### DIFF
--- a/packages/react-app-revamp/components/_pages/DialogFundRewardsModule/Form.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogFundRewardsModule/Form.tsx
@@ -75,9 +75,8 @@ export const Form = (props: FormProps) => {
   }, [isSuccess]);
 
   useEffect(() => {
-    if(query?.tokenRewardsAddress === "native") setData('isErc20', false)
-  }, [query?.tokenRewardsAddress])
-
+    if (query?.tokenRewardsAddress === "native") setData("isErc20", false);
+  }, [query?.tokenRewardsAddress]);
   return (
     <form ref={form} id={formId}>
       <fieldset className="mb-6">

--- a/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListProposals/index.tsx
@@ -23,7 +23,7 @@ export const ListProposals = () => {
     query: { chain, address },
   } = useRouter();
   const accountData = useAccount();
-  const network = useNetwork()
+  const network = useNetwork();
   const {
     contestAuthorEthereumAddress,
     amountOfTokensRequiredToSubmitEntry,
@@ -174,7 +174,7 @@ export const ListProposals = () => {
                       {!isProposalDeleted(listProposalsData[id].content) &&
                         contestAuthorEthereumAddress === accountData?.address && (
                           <button
-                            disabled={network?.chain?.name?.toLowerCase()?.replace(' ', "") !== chain ? true : false}
+                            disabled={network?.chain?.name?.toLowerCase()?.replace(" ", "") !== chain ? true : false}
                             onClick={() => onClickProposalDelete(id)}
                             className="hidden 2xs:flex mb-6 mx-2 2xs:text-2xs rounded-md 2xs:p-2.5 relative z-20 text-negative-12 hover:bg-negative-4 hover:bg-opacity-50 focus:bg-negative-2 focus:border-negative-8 border-negative-6 border border-solid disabled:opacity-50 disabled:cursor-not-allowed"
                           >
@@ -299,7 +299,7 @@ export const ListProposals = () => {
                         {!isProposalDeleted(listProposalsData[id].content) &&
                           contestAuthorEthereumAddress === accountData?.address && (
                             <button
-                              disabled={network?.chain?.name?.toLowerCase()?.replace(' ', "") !== chain ? true : false}
+                              disabled={network?.chain?.name?.toLowerCase()?.replace(" ", "") !== chain ? true : false}
                               onClick={() => onClickProposalDelete(id)}
                               className="flex items-center space-i-2 justify-center 2xs:hidden text-xs rounded-md py-1.5 px-3 relative z-20 text-negative-12 hover:bg-negative-4 hover:bg-opacity-50 focus:bg-negative-2 focus:border-negative-8 border-negative-6 border border-solid disabled:opacity-50 disabled:cursor-not-allowed"
                             >

--- a/packages/react-app-revamp/components/_pages/RewardsWinner/Reward.tsx
+++ b/packages/react-app-revamp/components/_pages/RewardsWinner/Reward.tsx
@@ -124,7 +124,6 @@ export const Reward = (props: RewardProps) => {
               )}
             </>
           )}
-          
         </>
       )}
     </section>

--- a/packages/react-app-revamp/components/_pages/RewardsWinner/index.tsx
+++ b/packages/react-app-revamp/components/_pages/RewardsWinner/index.tsx
@@ -34,41 +34,43 @@ export const RewardsWinner = (props: RewardsWinnerProps) => {
           {isError && "Something went wrong, please reload the page."}
           {data && (
             <>
-            <h2 className="font-bold text-lg mb-1">{`${ordinalize(payee)?.label}`} place: wins {`${((data.toNumber() * 100) / totalShares).toFixed(2)}`}% of all rewards</h2>
-            <ul>
-              <li>
-                <PayeeNativeReward
-                  share={data}
-                  payee={payee}
-                  chainId={
-                    chains.filter(chain => chain.name.toLowerCase().replace(" ", "") === asPath.split("/")?.[2])?.[0]
-                      ?.id
-                  }
-                  contractRewardsModuleAddress={contractRewardsModuleAddress}
-                  abiRewardsModule={abiRewardsModule}
-                />
-              </li>
-              {erc20Tokens?.length > 0 && (
-                <>
-                  {erc20Tokens.map((token: any) => (
-                    <li key={`payee-rank-${`${payee}`}-reward-token-${token.contractAddress}`}>
-                      <PayeeERC20Reward
-                        share={data}
-                        payee={payee}
-                        chainId={
-                          chains.filter(
-                            chain => chain.name.toLowerCase().replace(" ", "") === asPath.split("/")?.[2],
-                          )?.[0]?.id
-                        }
-                        tokenAddress={token.contractAddress}
-                        contractRewardsModuleAddress={contractRewardsModuleAddress}
-                        abiRewardsModule={abiRewardsModule}
-                      />
-                    </li>
-                  ))}
-                </>
-              )}
-            </ul>
+              <h2 className="font-bold text-lg mb-1">
+                Rank {`${payee}`}: wins {`${((data.toNumber() * 100) / totalShares).toFixed(2)}`}% of all rewards
+              </h2>
+              <ul>
+                <li>
+                  <PayeeNativeReward
+                    share={data}
+                    payee={payee}
+                    chainId={
+                      chains.filter(chain => chain.name.toLowerCase().replace(" ", "") === asPath.split("/")?.[2])?.[0]
+                        ?.id
+                    }
+                    contractRewardsModuleAddress={contractRewardsModuleAddress}
+                    abiRewardsModule={abiRewardsModule}
+                  />
+                </li>
+                {erc20Tokens?.length > 0 && (
+                  <>
+                    {erc20Tokens.map((token: any) => (
+                      <li key={`payee-rank-${`${payee}`}-reward-token-${token.contractAddress}`}>
+                        <PayeeERC20Reward
+                          share={data}
+                          payee={payee}
+                          chainId={
+                            chains.filter(
+                              chain => chain.name.toLowerCase().replace(" ", "") === asPath.split("/")?.[2],
+                            )?.[0]?.id
+                          }
+                          tokenAddress={token.contractAddress}
+                          contractRewardsModuleAddress={contractRewardsModuleAddress}
+                          abiRewardsModule={abiRewardsModule}
+                        />
+                      </li>
+                    ))}
+                  </>
+                )}
+              </ul>
             </>
           )}
         </>

--- a/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/Form.tsx
+++ b/packages/react-app-revamp/components/_pages/WizardFormCreateContest/Step3/Form.tsx
@@ -788,10 +788,8 @@ export const Form = (props: FormProps) => {
           >
             <RadioGroup.Label className="sr-only">Does your contest have rewards ?</RadioGroup.Label>
             <FormRadioOption value={"noRewards"}>No rewards</FormRadioOption>
-            <FormRadioOption value={"native"}>
-              Reward&nbsp; <span className="uppercase">${chain?.nativeCurrency?.symbol}</span>
-            </FormRadioOption>
-            <FormRadioOption value={"erc20"}>Reward another token on {chain?.name}</FormRadioOption>
+            <FormRadioOption value={"native"}>Reward {chain?.nativeCurrency?.symbol}</FormRadioOption>
+            <FormRadioOption value={"erc20"}>Reward another token</FormRadioOption>
           </FormRadioGroup>
           {data()?.rewardsType !== "noRewards" && (
             <div className="!mt-3 animate-appear max-w-[90%] 2xs:max-w-unset flex flex-col space-y-6 xs:pis-6">

--- a/packages/react-app-revamp/helpers/getRewardsModuleContractVersion.ts
+++ b/packages/react-app-revamp/helpers/getRewardsModuleContractVersion.ts
@@ -3,13 +3,12 @@ import { getProvider } from "@wagmi/core";
 import { chains } from "@config/wagmi";
 
 export async function getRewardsModuleContractVersion(address: string, chainName: string) {
-  const chainId = chains
-      .filter(chain => chain.name.toLowerCase().replace(" ", "") === chainName)?.[0]?.id;
-  const provider = await getProvider({chainId: chainId});
+  const chainId = chains.filter(chain => chain.name.toLowerCase().replace(" ", "") === chainName)?.[0]?.id;
+  const provider = await getProvider({ chainId: chainId });
   const bytecode = await provider.getCode(address);
 
   if (bytecode.length <= 2) return null;
-  
+
   return DeployedRewardsModuleContract.abi;
 }
 

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -275,7 +275,7 @@ export function useContest() {
       setVotesOpen(new Date(parseInt(results[7]) * 1000));
       // We want to track VoteCast event only 1H before the end of the contest
       if (isBefore(new Date(), closingVoteDate)) {
-        if (differenceInHours(closingVoteDate, new Date()) <= 1) {
+        if (differenceInHours(closingVoteDate, new Date()) <= 48) {
           // If the difference between the closing date (end of votes) and now is <= to 1h
           // reflect this in the state
           setCanUpdateVotesInRealTime(true);

--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -275,7 +275,7 @@ export function useContest() {
       setVotesOpen(new Date(parseInt(results[7]) * 1000));
       // We want to track VoteCast event only 1H before the end of the contest
       if (isBefore(new Date(), closingVoteDate)) {
-        if (differenceInHours(closingVoteDate, new Date()) <= 48) {
+        if (differenceInHours(closingVoteDate, new Date()) <= 1) {
           // If the difference between the closing date (end of votes) and now is <= to 1h
           // reflect this in the state
           setCanUpdateVotesInRealTime(true);

--- a/packages/react-app-revamp/hooks/useContest/store.ts
+++ b/packages/react-app-revamp/hooks/useContest/store.ts
@@ -9,6 +9,7 @@ export const createStore = () => {
     contestPrompt: null,
     contestAuthorEthereumAddress: null,
     contestAuthor: null,
+    contestStatus: null,
     submissionsOpen: null,
     votesOpen: null,
     votesClose: null,

--- a/packages/react-app-revamp/hooks/useContestEvents/index.ts
+++ b/packages/react-app-revamp/hooks/useContestEvents/index.ts
@@ -34,7 +34,6 @@ export function useContestEvents() {
    * @param args - Array of the following values: from, to, value, event|event[]
    */
   async function onVoteCast(args: Array<any>) {
-    console.log(new Date(), "vote cast event")
     try {
       const accountData = await getAccount();
       // if the connected wallet is the address that casted votes
@@ -88,7 +87,7 @@ export function useContestEvents() {
 
   useEffect(() => {
     if (canUpdateVotesInRealTime === false || contestStatus === CONTEST_STATUS.COMPLETED) {
-      provider.removeAllListeners("VoteCast")
+      provider.removeAllListeners()
 
     } else  {
       // Only watch VoteCast events when voting is open and we are <=1h before end of voting
@@ -121,11 +120,9 @@ useEffect(() => {
   );
 
   const onVisibilityChangeHandler = () => {
-    console.log("running", document.visibilityState, new Date())
     if (document.visibilityState === 'hidden') {
 
-      provider.removeAllListeners("VoteCast")
-
+      provider.removeAllListeners()
 
     } else {
       if (contestStatus === CONTEST_STATUS.VOTING_OPEN && canUpdateVotesInRealTime === true) {

--- a/packages/react-app-revamp/hooks/useContestEvents/index.ts
+++ b/packages/react-app-revamp/hooks/useContestEvents/index.ts
@@ -107,47 +107,47 @@ export function useContestEvents() {
 
   }, [canUpdateVotesInRealTime, contestStatus]);
 
-useEffect(() => {
-  watchContractEvent(
-    {
-      addressOrName: asPath.split("/")[3],
-      contractInterface: DeployedContestContract.abi,
-    },
-    "VoteCast",
-    (...args) => {
-      onVoteCast(args);
-    },
-  );
-
-  const onVisibilityChangeHandler = () => {
-    if (document.visibilityState === 'hidden') {
-
-      provider.removeAllListeners()
-
-    } else {
-      if (contestStatus === CONTEST_STATUS.VOTING_OPEN && canUpdateVotesInRealTime === true) {
-              provider.addListener( "VoteCast",
+  useEffect(() => {
+    watchContractEvent(
+      {
+        addressOrName: asPath.split("/")[3],
+        contractInterface: DeployedContestContract.abi,
+      },
+      "VoteCast",
       (...args) => {
         onVoteCast(args);
-      },)
+      },
+    );
 
+    const onVisibilityChangeHandler = () => {
+      if (document.visibilityState === 'hidden') {
+
+        provider.removeAllListeners()
+
+      } else {
+        if (contestStatus === CONTEST_STATUS.VOTING_OPEN && canUpdateVotesInRealTime === true) {
+                provider.addListener( "VoteCast",
+        (...args) => {
+          onVoteCast(args);
+        },)
+
+        }
       }
-    }
-};
+    };
 
-document.addEventListener(
-    'visibilitychange',
-    onVisibilityChangeHandler,
-);
-
-return () => {
-  document.removeEventListener(
+    document.addEventListener(
       'visibilitychange',
       onVisibilityChangeHandler,
-  );
-};
+    );
 
-}, [])
+    return () => {
+      document.removeEventListener(
+        'visibilitychange',
+        onVisibilityChangeHandler,
+      );
+    };
+
+  }, [])
   /*
   useContractEvent({
     addressOrName: asPath.split("/")[3],

--- a/packages/react-app-revamp/hooks/useProposalVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useProposalVotes/index.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import { useRouter } from "next/router";
 import shallow from "zustand/shallow";
-import { chain as wagmiChain, useAccount } from "wagmi";
+import { chain as wagmiChain, useAccount, useProvider } from "wagmi";
 import { getContract, watchContractEvent } from "@wagmi/core";
 import { fetchEnsName, getAccount, readContract } from "@wagmi/core";
 import DeployedContestContract from "@contracts/bytecodeAndAbi/Contest.sol/Contest.json";
@@ -18,7 +18,7 @@ const VOTES_PER_PAGE = 5;
 export function useProposalVotes(id: number | string) {
   const { asPath } = useRouter();
   const account = useAccount();
-  // const provider = useProvider();
+  const provider = useProvider();
   const [url] = useState(asPath.split("/"));
   const [chainId, setChainId] = useState(
     chains.filter(chain => chain.name.toLowerCase().replace(" ", "") === url[2])?.[0]?.id,
@@ -260,8 +260,27 @@ export function useProposalVotes(id: number | string) {
     }
   }, [canUpdateVotesInRealTime, contestStatus]);
 
+
+
   useEffect(() => {
     fetchProposalVotes();
+    const onVisibilityChangeHandler = () => {
+      if (document.visibilityState === 'hidden') {
+        provider.removeAllListeners()
+      } 
+    };
+
+    document.addEventListener(
+      'visibilitychange',
+      onVisibilityChangeHandler,
+    );
+
+    return () => {
+      document.removeEventListener(
+        'visibilitychange',
+        onVisibilityChangeHandler,
+      );
+    };
   }, []);
 
   return {

--- a/packages/react-app-revamp/hooks/useProposalVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useProposalVotes/index.ts
@@ -260,26 +260,18 @@ export function useProposalVotes(id: number | string) {
     }
   }, [canUpdateVotesInRealTime, contestStatus]);
 
-
-
   useEffect(() => {
     fetchProposalVotes();
     const onVisibilityChangeHandler = () => {
-      if (document.visibilityState === 'hidden') {
-        provider.removeAllListeners()
-      } 
+      if (document.visibilityState === "hidden") {
+        provider.removeAllListeners();
+      }
     };
 
-    document.addEventListener(
-      'visibilitychange',
-      onVisibilityChangeHandler,
-    );
+    document.addEventListener("visibilitychange", onVisibilityChangeHandler);
 
     return () => {
-      document.removeEventListener(
-        'visibilitychange',
-        onVisibilityChangeHandler,
-      );
+      document.removeEventListener("visibilitychange", onVisibilityChangeHandler);
     };
   }, []);
 

--- a/packages/react-app-revamp/layouts/LayoutViewContest/Sidebar/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/Sidebar/index.tsx
@@ -116,26 +116,25 @@ export const Sidebar = (props: any) => {
           </a>
         </Link>
         {supportsRewardsModule && (
-              <Link
-                href={{
-                  pathname: ROUTE_VIEW_CONTEST_REWARDS,
-                  //@ts-ignore
-                  query: {
-                    chain: query.chain,
-                    address: query.address,
-                  },
-                }}
-              >
-                <a
-                  className={`${styles.navLink} ${
-                    pathname === ROUTE_VIEW_CONTEST_REWARDS ? styles["navLink--active"] : ""
-                  }`}
-                >
-                  <IconTrophy className={styles.navLinkIcon} />
-                  Rewards
-                </a>
-              </Link>
-            
+          <Link
+            href={{
+              pathname: ROUTE_VIEW_CONTEST_REWARDS,
+              //@ts-ignore
+              query: {
+                chain: query.chain,
+                address: query.address,
+              },
+            }}
+          >
+            <a
+              className={`${styles.navLink} ${
+                pathname === ROUTE_VIEW_CONTEST_REWARDS ? styles["navLink--active"] : ""
+              }`}
+            >
+              <IconTrophy className={styles.navLinkIcon} />
+              Rewards
+            </a>
+          </Link>
         )}
         {contestStatus === CONTEST_STATUS.COMPLETED ? (
           <Link

--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -290,9 +290,12 @@ const LayoutViewContest = (props: any) => {
               {isSuccess && isError === null && !isLoading && (
                 <>
                   {displayReloadBanner === true && (
-                    <div className="mt-4 animate-appear justify-center xs:justify-between items-center p-3 rounded-md border-solid border border-neutral-4 mb-5 flex flex-wrap gap-y-3 gap-x-6 text-sm font-bold">
-                      <p className="text-center">Refresh the page to see the updated votes.</p>
-                      <Button intent="primary-outline" scale="sm" onClick={() => reload()}>
+                    <div className="mt-4 animate-appear p-3 rounded-md border-solid border border-neutral-4 mb-5 flex flex-col gap-y-3 text-sm font-bold">
+                      <div className="flex gap-1.5 flex-col">
+                        <span>Let&apos;s refresh!</span>
+                        <p className="font-normal">Looks like live updates were frozen.</p>
+                      </div>
+                      <Button className="w-full 2xs:w-fit-content" intent="primary-outline" scale="xs" onClick={() => reload()}>
                         <RefreshIcon className="mie-1ex w-4" />
                         Refresh
                       </Button>


### PR DESCRIPTION
# Description
* feat: disable event listeners in `useContractEvents` and `useProposalVotes` when the tab isn't focused
* feat: display 'refresh page' banner when user switches tab while realtime votes update is enabled

Demo: https://www.loom.com/share/fa8c53bb5b7e4d0f9c09208bf64306b3

![Screenshot 2023-01-26 at 12-14-36 JokeDAO 🃏 An open-source collaborative decision-making platform](https://user-images.githubusercontent.com/15010369/214822629-0177c717-afdd-474f-b0ff-136d62c8c954.png)

## Type of change
- [x] New feature