### PR TITLE
Interview bugfix

### DIFF
--- a/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
@@ -1,5 +1,5 @@
 import toast from "react-hot-toast";
-import { writeContract, waitForTransaction } from "@wagmi/core";
+import { writeContract, waitForTransaction, UserRejectedRequestError } from "@wagmi/core";
 import DeployedContestContract from "@contracts/bytecodeAndAbi/Contest.sol/Contest.json";
 import { useStore as useStoreSubmitProposal } from "./store";
 import { useStore as useStoreContest } from "./../useContest/store";
@@ -67,13 +67,18 @@ export function useSubmitProposal() {
       toast.success(`Your proposal was deployed successfully!`);
       increaseCurrentUserProposalCount();
     } catch (e) {
-      toast.error(
-        //@ts-ignore
-        e?.data?.message ?? "Something went wrong while deploying your proposal. Please try again.",
-      );
-      console.error(e);
       setIsLoading(false);
-      setError(e);
+
+      if (e instanceof UserRejectedRequestError) {
+        setError("Transaction was cancelled by the user");
+      } else {
+        //@ts-ignore
+        let errorMessage = e?.data?.message || "Something went wrong while deploying your proposal. Please try again.";
+        toast.error(errorMessage);
+        //@ts-ignore
+        setError(e.message);
+      }
+      console.error(e);
     }
   }
 


### PR DESCRIPTION
Task: Resolve the error that occurs when a user rejects the transaction to propose in Metamask.

Solution:

Error shown by the browser:
![Screenshot (109)](https://user-images.githubusercontent.com/69789526/216430051-51c1585c-5251-4790-a0cb-65463329eb61.png)

The error means that an object is being rendered directly as a React element. However, you can't use JavaScript Objects as a child in React.

To resolve the issue:
![Screenshot (110)](https://user-images.githubusercontent.com/69789526/216430505-ffdd2fd5-39db-4438-ae48-11df92a51205.png)

1. I discovered that the Error Object was the user rejecting the txn was being rendered directly as a React child which is not valid. So, I fixed that.
3. Then, I checked the type of error to ensure that it is an error due to UserRejectedRequest.
4. Then, I set the error to a string instead of an object to inform the user.
