### PR TITLE
bugfix: put the link to the proposal as the proposal content as to not overflow columns

### DIFF
--- a/packages/react-app-revamp/hooks/useExportContestDataToCSV/useExportContestDataToCSV.ts
+++ b/packages/react-app-revamp/hooks/useExportContestDataToCSV/useExportContestDataToCSV.ts
@@ -160,7 +160,7 @@ export function useExportContestDataToCSV() {
     const propId = listProposalsIds[i];
     if (propId) {
       const propTotalVotes = listProposalsData[propId].votes;
-      const propContent = listProposalsData[propId]?.content ?? "";
+      const propContent = "jokedao.io"+asPath.slice(0, asPath.indexOf("export-data"))+"proposal/"+propId.toString();
       const proposerAddress = listProposalsData[propId].authorEthereumAddress;
       const addressesVoted = await fetchProposalVoters(propId);
 


### PR DESCRIPTION
When we attempt to put the entirety of the proposal content into the excel column, if the proposal is long then it often overflows the column, making the data inconsistent amongst columns and the entire output difficult to read.

By only putting the link to the proposal, there will be consistency to how many characters are in each column and avoid the risk of data overflowing columns.