### PR TITLE
show switch network prompt after the contest is loaded to fix issue #153

### DIFF
--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -241,7 +241,7 @@ const LayoutViewContest = (props: any) => {
             </div>
           )}
 
-          {account?.address && chain?.id !== chainId && isBefore(new Date(), new Date(votesClose)) && (
+          {!isLoading && account?.address && chain?.id !== chainId && isBefore(new Date(), new Date(votesClose)) && (
             <div className="animate-appear flex text-center flex-col my-10 mx-auto">
               <p className="font-bold text-lg">Looks like you&apos;re using the wrong network.</p>
               <p className="mt-2 mb-4 text-neutral-11 text-xs">


### PR DESCRIPTION
changed file:
packages/react-app-revamp/layouts/LayoutViewContest/index.tsx

To ensure that the prompt for switching the network on the View Contest page is displayed only after the loading process has been completed, I added the condition "!isLoading" to the prompt.