### PR TITLE
bugfix: handle error correctly in useSubmitProposal and useCastVotes

### DIFF
--- a/packages/react-app-revamp/hooks/useCastVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useCastVotes/index.ts
@@ -71,11 +71,12 @@ export function useCastVotes() {
     } catch (e) {
       toast.error(
         //@ts-ignore
-        e?.data?.message ?? "Something went wrong while casting your votes.",
+        e?.message ?? "Something went wrong while casting your votes.",
       );
       console.error(e);
       setIsLoading(false);
-      setError(e);
+      //@ts-ignore
+      setError(e?.message);
     }
   }
 

--- a/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
@@ -69,11 +69,12 @@ export function useSubmitProposal() {
     } catch (e) {
       toast.error(
         //@ts-ignore
-        e?.data?.message ?? "Something went wrong while deploying your proposal. Please try again.",
+        e?.message ?? "Something went wrong while deploying your proposal. Please try again.",
       );
       console.error(e);
       setIsLoading(false);
-      setError(e);
+      //@ts-ignore
+      setError(e?.message);
     }
   }
 


### PR DESCRIPTION
The issue is caused by a caught error in `useSubmitProposal` which passes a non-renderable `object` element to `setError` and breaks the `TrackerDeployTransaction` component.

## Assessment
- Severity: Low/Medium — While not critical, rejecting a transaction is common and the issue can significantly degrade the ux of submitting a proposal, mainly by having to start again from scratch.
- Effort: Low
- Priority: Medium/High

## Debug process
- Reproduced the issue by creating a contest locally and rejecting tx while submitting a proposal
- Identified the [line that triggered it](https://github.com/JokeDAO/JokeDaoV2Dev/blob/main/packages/react-app-revamp/components/TrackerDeployTransaction/index.tsx#L31) and determined that the cause was `textError` being passed as an object and thus not renderable
- Traced back the logic to the error thrown in `useSubmitProposal`, derived context from surrounding code and other hooks, and with current knowledge decided the best course of action would be to use `e?.message` in both `toast.error` and `setError`. This is because:
  - The error description in e?.message is either a string or undefined, and both would not break the frontend
  - I found several instances around the codebase where the same logic had been implemented
- Finally I looked for other instances that may have triggered the same error, and found that `useCastVotes` had the same logic and was prone to same error. After reproducing it, I extended the fix to it as well.

## Considerations
- A generalised solution could be designed to handle errors in similar instances, improving maintainability and reducing surface area for bugs
- Updating dependencies to latest, refactoring code and improving type safety would help avoid this kind of bugs

---

Closes #133 