### PR TITLE
Issue fix: #113

### DIFF
--- a/packages/react-app-revamp/hooks/useCastVotes/index.ts
+++ b/packages/react-app-revamp/hooks/useCastVotes/index.ts
@@ -69,13 +69,9 @@ export function useCastVotes() {
       setIsSuccess(true);
       toast.success(`Your votes were cast successfully!`);
     } catch (e) {
-      toast.error(
-        //@ts-ignore
-        e?.data?.message ?? "Something went wrong while casting your votes.",
-      );
       console.error(e);
       setIsLoading(false);
-      setError(e);
+      setError("Something went wrong while casting your votes.");
     }
   }
 

--- a/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
@@ -67,13 +67,9 @@ export function useSubmitProposal() {
       toast.success(`Your proposal was deployed successfully!`);
       increaseCurrentUserProposalCount();
     } catch (e) {
-      toast.error(
-        //@ts-ignore
-        e?.data?.message ?? "Something went wrong while deploying your proposal. Please try again.",
-      );
       console.error(e);
       setIsLoading(false);
-      setError(e);
+      setError("Something went wrong while deploying your proposal. Please try again.");
     }
   }
 


### PR DESCRIPTION
fix for issue #113 

modified files `useSubmitProposal` and `useCastVotes` 

`useSubmitProposal` and `useCastVotes` were both setting the error incorrectly. the catch block was setting the error to `e`, the full error object, upon rejecting a tx (and any other errors that may result from wallet interaction), and objects are not valid react children. I set the error to a static string so it will render properly in the proposal submission modal and also so as to not expose the end user to a terse and confusing message. I also removed the toast being rendered in this instance, because the error message is displayed in the submission modal, and two different indicators confuse users. It could be either or, but it should only be one. Removing the toast also allowed for the removal of a ts-ignore, which is always a win.