### PR TITLE
bugfix: remove spaces in polygon evm name

### DIFF
--- a/packages/react-app-revamp/config/wagmi/custom-chains/polygonZkTestnet.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/polygonZkTestnet.ts
@@ -2,7 +2,7 @@ import { Chain } from '@wagmi/core'
 
 export const polygonZkTestnet = {
   id: 1422,
-  name: 'Polygon Zk Testnet',
+  name: 'PolygonZkTestnet',
   network: 'polygonZkTestnet',
   nativeCurrency: {
     decimals: 18,


### PR DESCRIPTION
With the spaces, this is what the url renders to which just isn't good practice.
<img width="472" alt="Screen Shot 2023-02-17 at 7 11 51 PM" src="https://user-images.githubusercontent.com/27874039/219819597-4c82ebf8-b9c8-4fa7-9d4f-b890135b48e2.png">
