### PR TITLE
Add better error handling and implement it in submit proposals

### DIFF
--- a/packages/react-app-revamp/components/TrackerDeployTransaction/index.tsx
+++ b/packages/react-app-revamp/components/TrackerDeployTransaction/index.tsx
@@ -3,23 +3,26 @@ import { CustomError, ErrorCodes } from "types/error";
 import styles from "./styles.module.css";
 
 interface TrackerDeployTransactionProps {
-  error: CustomError;
+  isError: boolean | CustomError;
   isLoading: boolean;
   isSuccess: boolean;
   transactionHref?: string;
   textSuccess?: React.ReactNode;
+  textError?: React.ReactNode;
   textPending?: React.ReactNode;
 }
 
 export const TrackerDeployTransaction: FC<TrackerDeployTransactionProps> = ({
-  error,
+  isError,
   isLoading,
   isSuccess,
   transactionHref,
   textSuccess,
+  textError,
   textPending,
 }) => {
-  const isUserRejectedTx = error?.code === ErrorCodes.USER_REJECTED_TX;
+  const isUserRejectedTx = (isError as CustomError)?.code === ErrorCodes.USER_REJECTED_TX;
+  const errorMessage = (isError as CustomError)?.message ?? textError;
 
   if (isUserRejectedTx) return null;
 
@@ -27,17 +30,17 @@ export const TrackerDeployTransaction: FC<TrackerDeployTransactionProps> = ({
     <>
       <ol className={`space-y-4 leading-[1.75] font-bold ${styles.stepper}`}>
         <li
-          className={`${isLoading || isSuccess ? "text-primary-10" : error ? "text-negative-11" : "text-true-white"} ${
-            isLoading ? "animate-pulse" : ""
-          }`}
+          className={`${
+            isLoading || isSuccess ? "text-primary-10" : isError ? "text-negative-11" : "text-true-white"
+          } ${isLoading ? "animate-pulse" : ""}`}
         >
-          {error ? "Something went wrong during deployment." : textPending ?? "Deploying transaction..."}
+          {isError ? "Something went wrong during deployment." : textPending ?? "Deploying transaction..."}
         </li>
         <li className={isSuccess ? "text-primary-10" : "text-neutral-8"}>{textSuccess ?? "Deployed"}!</li>
       </ol>
-      {error && (
+      {isError && (
         <p className="animate-appear mt-3 rounded bor px-4 border border-solid border-negative-4 py-2 text-negative-11 bg-negative-1">
-          {error?.message}
+          {errorMessage}
         </p>
       )}
 

--- a/packages/react-app-revamp/components/TrackerDeployTransaction/index.tsx
+++ b/packages/react-app-revamp/components/TrackerDeployTransaction/index.tsx
@@ -1,37 +1,47 @@
+import { FC } from "react";
+import { CustomError, ErrorCodes } from "types/error";
 import styles from "./styles.module.css";
+
 interface TrackerDeployTransactionProps {
-  isError: boolean;
+  error: CustomError;
   isLoading: boolean;
   isSuccess: boolean;
   transactionHref?: string;
   textSuccess?: React.ReactNode;
-  textError?: React.ReactNode;
   textPending?: React.ReactNode;
 }
-export const TrackerDeployTransaction = (props: TrackerDeployTransactionProps) => {
-  const { isError, isLoading, isSuccess, transactionHref, textSuccess, textError, textPending } = props;
+
+export const TrackerDeployTransaction: FC<TrackerDeployTransactionProps> = ({
+  error,
+  isLoading,
+  isSuccess,
+  transactionHref,
+  textSuccess,
+  textPending,
+}) => {
+  const isUserRejectedTx = error?.code === ErrorCodes.USER_REJECTED_TX;
+
+  if (isUserRejectedTx) return null;
+
   return (
     <>
       <ol className={`space-y-4 leading-[1.75] font-bold ${styles.stepper}`}>
         <li
-          className={`${
-            isLoading === true || isSuccess === true
-              ? "text-primary-10"
-              : isError === true
-              ? "text-negative-11"
-              : "text-true-white"
-          } ${isLoading === true ? "animate-pulse" : ""}`}
+          className={`${isLoading || isSuccess ? "text-primary-10" : error ? "text-negative-11" : "text-true-white"} ${
+            isLoading ? "animate-pulse" : ""
+          }`}
         >
-          {isError ? "Something went wrong during deployment." : textPending ?? "Deploying transaction..."}
+          {error ? "Something went wrong during deployment." : textPending ?? "Deploying transaction..."}
         </li>
-        <li className={isSuccess === true ? "text-primary-10" : "text-neutral-8"}>{textSuccess ?? "Deployed"}!</li>
+        <li className={isSuccess ? "text-primary-10" : "text-neutral-8"}>{textSuccess ?? "Deployed"}!</li>
       </ol>
-      {isError && textError && (
+      {error && (
         <p className="animate-appear mt-3 rounded bor px-4 border border-solid border-negative-4 py-2 text-negative-11 bg-negative-1">
-          {textError}
+          {error?.message}
         </p>
       )}
-      {isSuccess === true && transactionHref && (
+
+      {isSuccess && transactionHref && (
         <>
           <a className="mt-5 block" rel="nofollow noreferrer" target="_blank" href={transactionHref}>
             View transaction <span className="link">here</span>

--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
@@ -128,7 +128,7 @@ export const DialogModalSendProposal = (props: DialogModalSendProposalProps) => 
     <DialogModal title="Submit your proposal" {...props}>
       {showDeploymentSteps && (
         <div className="animate-appear mt-2 mb-4">
-          <TrackerDeployTransaction isSuccess={isSuccess} error={error} isLoading={isLoading} />
+          <TrackerDeployTransaction isSuccess={isSuccess} isLoading={isLoading} isError={error} />
         </div>
       )}
 

--- a/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
+++ b/packages/react-app-revamp/components/_pages/DialogModalSendProposal/index.tsx
@@ -128,12 +128,7 @@ export const DialogModalSendProposal = (props: DialogModalSendProposalProps) => 
     <DialogModal title="Submit your proposal" {...props}>
       {showDeploymentSteps && (
         <div className="animate-appear mt-2 mb-4">
-          <TrackerDeployTransaction
-            textError={error}
-            isSuccess={isSuccess}
-            isError={error !== null}
-            isLoading={isLoading}
-          />
+          <TrackerDeployTransaction isSuccess={isSuccess} error={error} isLoading={isLoading} />
         </div>
       )}
 
@@ -156,13 +151,6 @@ export const DialogModalSendProposal = (props: DialogModalSendProposalProps) => 
           </Link>
         </div>
       )}
-      {error !== null && !isSuccess && contestStatus === CONTEST_STATUS.SUBMISSIONS_OPEN && (
-        <>
-          <Button onClick={onSubmitProposal} intent="neutral-outline" type="submit" className="mx-auto my-3">
-            Try again
-          </Button>
-        </>
-      )}
 
       {currentUserSubmitProposalTokensAmount >= amountOfTokensRequiredToSubmitEntry &&
       currentUserProposalCount < contestMaxNumberSubmissionsPerUser &&
@@ -184,7 +172,7 @@ export const DialogModalSendProposal = (props: DialogModalSendProposalProps) => 
                 <Button
                   disabled={proposal.trim().length === 0 || isLoading}
                   type="submit"
-                  className={isLoading || error !== null ? "hidden" : "mt-3"}
+                  className={isLoading ? "hidden" : "mt-3"}
                 >
                   Submit!
                 </Button>

--- a/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useSubmitProposal/index.ts
@@ -67,13 +67,10 @@ export function useSubmitProposal() {
       toast.success(`Your proposal was deployed successfully!`);
       increaseCurrentUserProposalCount();
     } catch (e) {
-      toast.error(
-        //@ts-ignore
-        e?.data?.message ?? "Something went wrong while deploying your proposal. Please try again.",
-      );
-      console.error(e);
-      setIsLoading(false);
+      //@ts-ignore
+      toast.error(e?.message);
       setError(e);
+      setIsLoading(false);
     }
   }
 

--- a/packages/react-app-revamp/hooks/useSubmitProposal/store.ts
+++ b/packages/react-app-revamp/hooks/useSubmitProposal/store.ts
@@ -1,3 +1,4 @@
+import { CustomError } from "types/error";
 import create from "zustand";
 import createContext from "zustand/context";
 
@@ -12,7 +13,7 @@ export const createStore = () => {
     setIsModalOpen: (value: boolean) => set({ isModalOpen: value }),
     setIsLoading: (value: boolean) => set({ isLoading: value }),
     setIsSuccess: (value: boolean) => set({ isSuccess: value }),
-    setError: (value: null | string) => set({ error: value }),
+    setError: (value: CustomError | null) => set({ error: value }),
   }));
 };
 

--- a/packages/react-app-revamp/types/error.ts
+++ b/packages/react-app-revamp/types/error.ts
@@ -1,0 +1,8 @@
+export interface CustomError {
+  message?: string;
+  code?: number;
+}
+
+export enum ErrorCodes {
+  USER_REJECTED_TX = 4001,
+}


### PR DESCRIPTION
## What does this PR do and why?

Closes https://github.com/JokeDAO/JokeDaoV2Dev/issues/133

In this PR, I've decided to refactor `TrackedDeployTransaction` and I will explain why I went that route.

An issue was discovered in the `useSubmitProposal` hook's catch block, which triggered the `TrackerDeployTransaction` component. The issue was caused by setting the `setError` function to the entire error object instead of just the error message string.

To fix the issue, we modified the code to set `setError` to the error message string instead of the entire object. This correction allowed the application and `TrackerDeployTransaction` component to function as expected.
### Process
The idea that errors when the user cancels metamask transactions are treated the same as other "classic" errors bothered me, and this is why.

Let's use web2 world as an example. Suppose you are filling out the form and going through the checkout process when you decide that some of the form fields you filled out are not satisfied. You click the cancel button and go back to filling out the form. Since you just canceled the process, the user interface is not swamped with errors, so there is no need for you to be worried.

In the web3 world, a user's rejection of a transaction is viewed as an error — we can't change that; it just is.
But is it really an error, and why clutter the user interface when it's not needed? Can't we differentiate between user rejection of a transaction and other errors?
Yeah, thanks to `error-constants.ts` at https://github.com/MetaMask/eth-rpc-errors.

We can view all of the error codes that metamask sends us here, and we are certain that error code `4001` means the user rejected the request. I like this because it serves as a visual reference to the user that there was nothing wrong with the transaction—you just canceled it due to needing to change something in the form or not performing it at all.

### Execution
Following the outlined process, I have developed an MVP version that includes modifications to the `TrackerDeployTransaction` component. Although I have retained the older properties due to their use in multiple files, my intention is to adopt a new structure in future development that incorporates `CustomError`.

With the `CustomError` approach, we would only need to pass the error object, which would contain the structure of the `CustomError` object. This object would contain messages, codes, and any other relevant data that we choose to include.

The adoption of the `CustomError` approach eliminates the need to pass multiple error props, such as `isError` or `textError`. Instead, one object contains all the required data, streamlining the error-handling process.

It's worth noting that the `CustomError` approach is currently only used in the submit proposal component. Overall, this approach leads to better application performance and a smoother user experience.

### Screenshots or screen recordings

### Before

https://user-images.githubusercontent.com/18723426/219975592-b7411015-f6ca-4e92-b618-9479aee17697.mov


### After

https://user-images.githubusercontent.com/18723426/219975604-8f6be1ce-1506-4c08-b601-247d1ccb6224.mov

