### PR TITLE
bugfix: update sepolia endpoint

### DIFF
--- a/packages/react-app-revamp/config/wagmi/custom-chains/sepolia.ts
+++ b/packages/react-app-revamp/config/wagmi/custom-chains/sepolia.ts
@@ -8,8 +8,8 @@ export const sepolia = {
     symbol: 'ETH',
   },
   rpcUrls: {
-    public: 'https://rpc.sepolia.dev',
-    default: 'https://rpc.sepolia.dev',
+    public: 'https://rpc.sepolia.org/',
+    default: 'https://rpc.sepolia.org/',
   },
   blockExplorers: {
     etherscan: { name: 'Sepolia Etherscan', url: 'https://sepolia.etherscan.io' },


### PR DESCRIPTION
Was running into issues with server errors such as "Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at [https://rpc.sepolia.dev](https://rpc.sepolia.dev)." and server response errors for `eth_getCode` calls for [https://rpc.sepolia.dev](https://rpc.sepolia.dev).

[https://rpc.sepolia.org/](https://rpc.sepolia.org/) is working though!