### PR TITLE
chore: add project to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,6 +4,7 @@ about: Create a report to help us improve
 title: "bug: "
 labels: bug
 assignees: ''
+projects: jokedao roadmap organization
 
 ---
 


### PR DESCRIPTION
Since we make the Github project public, we'll just have issues auto-assigned there when users create them!