### PR TITLE
bug: remove bullet points from pagination in contests

### DIFF
--- a/packages/react-app-revamp/components/_pages/ListContests/index.tsx
+++ b/packages/react-app-revamp/components/_pages/ListContests/index.tsx
@@ -114,7 +114,7 @@ export const ListContests = (props: ListContestsProps) => {
                     <span className="sr-only sm:not-sr-only text-xs">Previous</span>
                   </Pagination.PrevButton>
 
-                  <div className="flex items-center flex-wrap justify-center flex-grow">
+                  <div className="flex items-center flex-wrap justify-center flex-grow no-marker">
                     <Pagination.PageButton
                       activeClassName="bg-primary-10 text-primary-1 hover:bg-opacity-90 focus:bg-primary-11"
                       inactiveClassName="bg-true-black text-neutral-10 hover:bg-true-white hover:bg-opacity-5 focus:bg-true-white focus:bg-opacity-10"

--- a/packages/react-app-revamp/styles/globals.css
+++ b/packages/react-app-revamp/styles/globals.css
@@ -125,6 +125,11 @@
   .container {
     @apply px-5 lg:px-3 max-w-screen-lg;
   }
+
+  .no-marker li::marker {
+    content: "";
+  }
+
   .form-field--disabled {
     @apply opacity-50 cursor-not-allowed;
   }


### PR DESCRIPTION
## What does this PR do and why?

Closes https://github.com/JokeDAO/JokeDaoV2Dev/issues/208

Library `react-headless-pagination` that we use for pagination was causing bullet points to act weirdly around our components, I found a way to define a custom class for tailwind components that we use and removed them.

## Screenshots or screen recordings
![image](https://user-images.githubusercontent.com/18723426/227719136-142cff99-a4ef-4ef3-b41e-1925b9275071.png)
