### PR TITLE
bug: remove duplication of code in useContest hook

### DIFF
--- a/packages/react-app-revamp/hooks/useContest/index.ts
+++ b/packages/react-app-revamp/hooks/useContest/index.ts
@@ -1,3 +1,4 @@
+import { supabase } from "@config/supabase";
 import { chains } from "@config/wagmi";
 import { CONTEST_STATUS } from "@helpers/contestStatus";
 import getContestContractVersion from "@helpers/getContestContractVersion";
@@ -273,39 +274,29 @@ export function useContest() {
         setIsUserStoreLoading(false);
       }
 
+      // If this contest doesn't exist in the database, index it
       if (
         process.env.NEXT_PUBLIC_SUPABASE_URL !== "" &&
         process.env.NEXT_PUBLIC_SUPABASE_URL &&
         process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY !== "" &&
         process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
       ) {
-        const config = await import("@config/supabase");
-        const supabase = config.supabase;
-
-        // If this contest doesn't exist in the database, index it
-        if (
-          process.env.NEXT_PUBLIC_SUPABASE_URL !== "" &&
-          process.env.NEXT_PUBLIC_SUPABASE_URL &&
-          process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY !== "" &&
-          process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-        ) {
-          const indexingResult = await supabase.from("contests").select("*").eq("address", address);
-          if (indexingResult && indexingResult?.data && indexingResult?.data?.length === 0) {
-            indexContest({
-              //@ts-ignore
-              datetimeOpeningSubmissions: new Date(parseInt(results[5]) * 1000).toISOString(),
-              //@ts-ignore
-              datetimeOpeningVoting: new Date(parseInt(results[7]) * 1000).toISOString(),
-              //@ts-ignore
-              datetimeClosingVoting: new Date(parseInt(results[6]) * 1000),
-              contestTitle: results[0],
-              daoName: null,
-              contractAddress: address,
-              authorAddress: results[1],
-              votingTokenAddress: results[4],
-              networkName: asPath.split("/")[2],
-            });
-          }
+        const indexingResult = await supabase.from("contests").select("*").eq("address", address);
+        if (indexingResult && indexingResult?.data && indexingResult?.data?.length === 0) {
+          indexContest({
+            //@ts-ignore
+            datetimeOpeningSubmissions: new Date(parseInt(results[5]) * 1000).toISOString(),
+            //@ts-ignore
+            datetimeOpeningVoting: new Date(parseInt(results[7]) * 1000).toISOString(),
+            //@ts-ignore
+            datetimeClosingVoting: new Date(parseInt(results[6]) * 1000),
+            contestTitle: results[0],
+            daoName: null,
+            contractAddress: address,
+            authorAddress: results[1],
+            votingTokenAddress: results[4],
+            networkName: asPath.split("/")[2],
+          });
         }
       }
     } catch (e) {


### PR DESCRIPTION
## What does this PR do and why?

Closes https://github.com/JokeDAO/JokeDaoV2Dev/issues/218

The code duplication issue in the `useContest` hook, specifically when indexing a non-existent contest, has been resolved. This PR aims to remove the redundant code to maintain codebase cleanliness and efficiency.