### PR TITLE
bug: contest status floating on proposals page

### DIFF
--- a/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
+++ b/packages/react-app-revamp/layouts/LayoutViewContest/index.tsx
@@ -182,7 +182,11 @@ const LayoutViewContest = (props: any) => {
           votesOpen &&
           votesClose &&
           [CONTEST_STATUS.SUBMISSIONS_OPEN, CONTEST_STATUS.VOTING_OPEN].includes(contestStatus) && (
-            <div className="animate-appear text-center text-xs sticky bg-neutral-0 border-b border-neutral-4 border-solid top-10 z-10 font-bold -mx-5 px-5 md:hidden w-screen py-1">
+            <div
+              className={`animate-appear text-center text-xs sticky bg-neutral-0 border-b border-neutral-4 border-solid ${
+                pathname === ROUTE_CONTEST_PROPOSAL ? "top-0" : "top-10"
+              } z-10 font-bold -mx-5 px-5 md:hidden w-screen py-1`}
+            >
               <p className="text-center">
                 {!isLoading && isSuccess && isDate(submissionsOpen) && isDate(votesOpen) && isDate(votesClose) && (
                   <>


### PR DESCRIPTION
## What does this PR do and why?

We discovered a mobile bug that was posted in our TG group, when the user scrolls through the proposals page, the contest status is not fixed on top.

## Screenshots or screen recordings

https://user-images.githubusercontent.com/18723426/229784769-c8be26f2-298e-474a-8a94-f45fa3d67fce.mov

