### PR TITLE
bug: use chain list defined in config/wagmi instead of network hook

### DIFF
--- a/packages/react-app-revamp/hooks/useProposal/index.ts
+++ b/packages/react-app-revamp/hooks/useProposal/index.ts
@@ -1,3 +1,4 @@
+import { chains } from "@config/wagmi";
 import arrayToChunks from "@helpers/arrayToChunks";
 import getContestContractVersion from "@helpers/getContestContractVersion";
 import isUrlToImage from "@helpers/isUrlToImage";
@@ -30,7 +31,7 @@ export function useProposal() {
   const [chainName, address] = asPath.split("/").slice(2, 4);
 
   const { setIsLoading, setIsSuccess, setError } = useContestStore(state => state);
-  const { chain, chains } = useNetwork();
+  const { chain } = useNetwork();
   const { increaseCurrentUserProposalCount } = useUserStore(state => state);
 
   function onContractError(err: any) {

--- a/packages/react-app-revamp/hooks/useUser/index.ts
+++ b/packages/react-app-revamp/hooks/useUser/index.ts
@@ -1,3 +1,4 @@
+import { chains } from "@config/wagmi";
 import getContestContractVersion from "@helpers/getContestContractVersion";
 import { useContestStore } from "@hooks/useContest/store";
 import { useProposalStore } from "@hooks/useProposal/store";
@@ -26,7 +27,7 @@ export function useUser() {
     setSnapshotTaken,
     setError: setContestError,
   } = useContestStore(state => state);
-  const { chain, chains } = useNetwork();
+  const { chain } = useNetwork();
   const { asPath } = useRouter();
   const [chainName, address] = asPath.split("/").slice(2, 4);
 


### PR DESCRIPTION
## What does this PR do and why?

If you go to the latest jokerace deployed on zkRollup and you are not connected with a wallet, the proposal won't load and error will come in.

This is some weird behavior from `useNetwork` hook, it treats these chains as undefined, therefore also to keep consistent, let's retrieve chains from `config/wagmi` like in other components.

URL to trigger error - https://www.jokedao.io/contest/polygonzkmainnet/0x6954FCfB44bb24B5fD51B8A96ABbd9E84eD5cAEd